### PR TITLE
Fix efficiency bonus calculation

### DIFF
--- a/lib/ScoringEngine.js
+++ b/lib/ScoringEngine.js
@@ -301,13 +301,16 @@ class ScoringEngine {
         let timeBonus = 0;
 
         // Efficiency bonus: fewer actions to complete more items
-        const actionsPerCompletedItem = completionStatus.completedItems > 0 ? 
+        const actionsPerCompletedItem = completionStatus.completedItems > 0 ?
             actionLog.totalActions / completionStatus.completedItems : 0;
 
-        if (actionsPerCompletedItem > 0 && actionsPerCompletedItem < 2) {
-            efficiencyBonus = 2; // Very efficient
-        } else if (actionsPerCompletedItem < 3) {
-            efficiencyBonus = 1; // Moderately efficient
+        // Only award efficiency bonuses when at least one item is completed
+        if (completionStatus.completedItems > 0) {
+            if (actionsPerCompletedItem < 2) {
+                efficiencyBonus = 2; // Very efficient
+            } else if (actionsPerCompletedItem < 3) {
+                efficiencyBonus = 1; // Moderately efficient
+            }
         }
 
         // Time bonus: completing case quickly (under 15 minutes)

--- a/test/ScoringEngineEfficiency.test.js
+++ b/test/ScoringEngineEfficiency.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import ScoringEngine from '../lib/ScoringEngine.js';
+import PerformanceTracker from '../lib/PerformanceTracker.js';
+import fs from 'fs';
+import path from 'path';
+
+describe('ScoringEngine efficiency bonus', () => {
+    it('does not award efficiency bonus when no checklist items are completed', () => {
+        const casePath = path.join(process.cwd(), 'cases', 'stemi-001.json');
+        const caseData = JSON.parse(fs.readFileSync(casePath, 'utf8'));
+        const tracker = new PerformanceTracker();
+        tracker.initializeChecklist(caseData);
+        const performanceData = tracker.getPerformanceData();
+        const engine = new ScoringEngine();
+        const result = engine.calculateScore(performanceData, caseData.checklist);
+        expect(result.efficiencyBonus).toBe(0);
+        expect(result.totalScore).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- avoid granting efficiency points when no checklist items are completed
- add test ensuring efficiency bonus remains zero when nothing is done

## Testing
- `npm test -- test/ScoringEngineEfficiency.test.js`
- `npm test` *(fails: API Error and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b40df0a788327b10d4e49f2d6e33b