### PR TITLE
Rebuild mcq component using shadcn vue patterns

### DIFF
--- a/webapp/resources/js/components/ui/mcq/MCQ.vue
+++ b/webapp/resources/js/components/ui/mcq/MCQ.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from 'vue'
-import { ref, computed } from 'vue'
-import { cn } from '@/lib/utils'
-import { Primitive, type PrimitiveProps } from 'reka-ui'
-import { type MCQVariants, mcqVariants } from '.'
+import { computed } from 'vue'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
 
 interface MCQOption {
   id: string
@@ -18,21 +18,15 @@ interface MCQData {
   explanation?: string
 }
 
-interface Props extends PrimitiveProps {
+interface Props {
   data: MCQData
-  variant?: MCQVariants['variant']
-  size?: MCQVariants['size']
   showExplanation?: boolean
   showCorrectAnswer?: boolean
-  class?: HTMLAttributes['class']
   selectedAnswer?: string | null
   onAnswerSelect?: (selectedAnswer: string, isCorrect: boolean) => void
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  as: 'div',
-  variant: 'default',
-  size: 'default',
   showExplanation: false,
   showCorrectAnswer: false,
   selectedAnswer: null,
@@ -43,13 +37,22 @@ const emit = defineEmits<{
 }>()
 
 const isAnswered = computed(() => {
-  return props.selectedAnswer !== null && props.selectedAnswer !== undefined
+  return props.selectedAnswer !== null && props.selectedAnswer !== undefined && props.selectedAnswer !== ''
 })
 
 const isCorrect = computed(() => {
   if (!props.selectedAnswer || !props.data.correctAnswer) return false
   return props.selectedAnswer === props.data.correctAnswer
 })
+
+const isOptionSelected = (optionValue: string) => props.selectedAnswer === optionValue
+
+const getOptionVariant = (optionValue: string): 'default' | 'secondary' | 'outline' | 'destructive' => {
+  if (!isAnswered.value) return 'outline'
+  if (isOptionSelected(optionValue) && isCorrect.value) return 'secondary'
+  if (isOptionSelected(optionValue) && !isCorrect.value) return 'destructive'
+  return 'outline'
+}
 
 const handleOptionSelect = (optionValue: string) => {
   if (isAnswered.value) return
@@ -63,82 +66,48 @@ const handleOptionSelect = (optionValue: string) => {
 }
 
 const resetQuiz = () => {
-  emit('answerSelect', '', false) // Emit empty string to reset
+  emit('answerSelect', '', false)
 }
 </script>
 
 <template>
-  <Primitive :as="as" :as-child="asChild" :class="cn(mcqVariants({ variant, size }), props.class)">
-    <div class="w-full">
-      <!-- Question -->
-      <div class="mb-4">
-        <h3 class="text-lg font-semibold text-foreground mb-3">
-          {{ data.question }}
-        </h3>
+  <Card class="w-full">
+    <CardHeader>
+      <CardTitle>{{ data.question }}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div class="space-y-2">
+        <Button
+          v-for="option in data.options"
+          :key="option.id"
+          :variant="getOptionVariant(option.value)"
+          class="w-full justify-between text-left"
+          :disabled="isAnswered"
+          @click="handleOptionSelect(option.value)"
+        >
+          <span class="font-medium">{{ option.text }}</span>
+          <template v-if="isAnswered">
+            <Badge v-if="isOptionSelected(option.value) && isCorrect" variant="default">Correct</Badge>
+            <Badge v-else-if="isOptionSelected(option.value) && !isCorrect" variant="destructive">Incorrect</Badge>
+            <Badge v-else-if="option.value === data.correctAnswer && showCorrectAnswer" variant="default">Correct</Badge>
+          </template>
+        </Button>
       </div>
 
-      <!-- Options -->
-      <div class="space-y-2 mb-4">
-        <div v-for="option in data.options" :key="option.id" @click="handleOptionSelect(option.value)" :class="cn(
-          'p-3 rounded-3xl border-2 cursor-pointer transition-all duration-200',
-          'hover:border-primary/50 hover:bg-accent/50',
-          {
-            'border-primary bg-primary/10 text-primary':
-              props.selectedAnswer === option.value && isCorrect,
-            'border-destructive bg-destructive/10 text-destructive':
-              props.selectedAnswer === option.value && !isCorrect && isAnswered,
-            'border-input bg-background':
-              props.selectedAnswer !== option.value || !isAnswered,
-            'pointer-events-none': isAnswered,
-          }
-        )">
-          <div class="flex items-center justify-between">
-            <span class="font-medium">{{ option.text }}</span>
-            <div v-if="isAnswered" class="flex items-center gap-2">
-              <span v-if="props.selectedAnswer === option.value && isCorrect"
-                class="text-green-600 dark:text-green-400">
-                ✓
-              </span>
-              <span v-else-if="props.selectedAnswer === option.value && !isCorrect"
-                class="text-red-600 dark:text-red-400">
-                ✗
-              </span>
-              <span v-else-if="option.value === data.correctAnswer && showCorrectAnswer"
-                class="text-green-600 dark:text-green-400">
-                ✓
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Explanation -->
-      <div v-if="showExplanation && data.explanation && isAnswered"
-        class="mb-4 p-3 rounded-3xl bg-muted/50 border border-border">
-        <h4 class="font-medium text-foreground mb-2">Explanation:</h4>
-        <p class="text-muted-foreground text-sm">{{ data.explanation }}</p>
-      </div>
-
-      <!-- Result Message -->
-      <div v-if="isAnswered" class="mb-4 p-3 rounded-3xl text-center" :class="cn(
-        'border-2',
-        {
-          'border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200': isCorrect,
-          'border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200': !isCorrect,
-        }
-      )">
-        <p class="font-medium text-sm">
-          {{ isCorrect ? 'Correct!' : 'Incorrect. Try again!' }}
-        </p>
-      </div>
-
-      <!-- Reset Button -->
-      <div v-if="isAnswered" class="flex justify-center">
-        <button @click="resetQuiz"
-          class="px-4 py-2 rounded-3xl bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors text-sm">
-          Try Another Question
-        </button>
-      </div>
-    </div>
-  </Primitive>
+      <template v-if="showExplanation && data.explanation && isAnswered">
+        <Separator class="my-4" />
+        <Card>
+          <CardHeader>
+            <CardTitle class="text-base">Explanation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p class="text-muted-foreground text-sm">{{ data.explanation }}</p>
+          </CardContent>
+        </Card>
+      </template>
+    </CardContent>
+    <CardFooter v-if="isAnswered" class="justify-center">
+      <Button variant="secondary" @click="resetQuiz">Try Another Question</Button>
+    </CardFooter>
+  </Card>
 </template>

--- a/webapp/resources/js/components/ui/mcq/index.ts
+++ b/webapp/resources/js/components/ui/mcq/index.ts
@@ -1,29 +1,2 @@
-import { cva, type VariantProps } from 'class-variance-authority'
-
 export { default as MCQ } from './MCQ.vue'
 
-export const mcqVariants = cva(
-  'w-full',
-  {
-    variants: {
-      variant: {
-        default: 'bg-background text-foreground',
-        card: 'bg-card text-card-foreground border border-border rounded-3xl p-4 shadow-sm',
-        outline: 'border-2 border-border rounded-3xl p-4',
-        ghost: 'bg-transparent',
-      },
-      size: {
-        default: 'text-base',
-        sm: 'text-sm',
-        lg: 'text-lg',
-        xl: 'text-xl',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
-    },
-  },
-)
-
-export type MCQVariants = VariantProps<typeof mcqVariants>

--- a/webapp/resources/js/pages/MCQDemo.vue
+++ b/webapp/resources/js/pages/MCQDemo.vue
@@ -4,6 +4,9 @@ import { ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
 import { Head } from '@inertiajs/vue3'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { toast } from 'vue-sonner'
 
 // Sample MCQ data
 const sampleMCQs = [
@@ -67,6 +70,13 @@ const handleAnswerSelect = (selectedAnswer: string, isCorrect: boolean) => {
     }
 
     selectedAnswers.value[currentQuestionIndex.value] = selectedAnswer === '' ? null : selectedAnswer
+
+    if (selectedAnswer === '') return
+    if (isCorrect) {
+        toast.success('Correct answer')
+    } else {
+        toast.error('Incorrect answer')
+    }
 }
 
 const nextQuestion = () => {
@@ -111,20 +121,18 @@ const breadcrumbs: BreadcrumbItem[] = [
             </div>
             <!-- Navigation -->
             <div class="flex justify-between mb-6">
-                <button @click="previousQuestion" :disabled="currentQuestionIndex === 0"
-                    class="px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                <Button variant="secondary" @click="previousQuestion" :disabled="currentQuestionIndex === 0">
                     ← Previous
-                </button>
-                <button @click="nextQuestion" :disabled="currentQuestionIndex === sampleMCQs.length - 1"
-                    class="px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                </Button>
+                <Button variant="secondary" @click="nextQuestion" :disabled="currentQuestionIndex === sampleMCQs.length - 1">
                     Next →
-                </button>
+                </Button>
             </div>
 
             <!-- MCQ Component -->
             <div class="mb-8">
                 <MCQ :data="sampleMCQs[currentQuestionIndex]" :selected-answer="selectedAnswers[currentQuestionIndex]"
-                    variant="card" size="lg" :show-explanation="true" :show-correct-answer="true"
+                    :show-explanation="true" :show-correct-answer="true"
                     @answer-select="handleAnswerSelect" />
             </div>
         </div>


### PR DESCRIPTION
Rebuilds the MCQ component and demo page using ShadCN Vue patterns to ensure architectural consistency and improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-13ac1331-9e37-4161-852e-e52485d59d3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13ac1331-9e37-4161-852e-e52485d59d3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

