### PR TITLE
feat: add per-second session countdown

### DIFF
--- a/webapp/resources/js/pages/Osce.vue
+++ b/webapp/resources/js/pages/Osce.vue
@@ -67,6 +67,7 @@ const props = defineProps<{
 // Create reactive refs for data that can change
 const userSessions = ref<OsceSession[]>(props.userSessions);
 let timerRefreshInterval: number | undefined;
+const sessionCountdowns: Record<number, number> = {};
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -104,11 +105,14 @@ async function refreshActiveSessionTimers() {
                         remaining_seconds: timerData.remaining_seconds,
                         time_status: timerData.time_status
                     };
-                    
-                    // Auto-complete expired sessions
+
                     if (timerData.time_status === 'expired') {
                         userSessions.value[sessionIndex].status = 'completed';
+                        clearInterval(sessionCountdowns[session.id]);
+                        delete sessionCountdowns[session.id];
                         toast.info(`OSCE session "${session.osce_case?.title}" has expired and been completed.`);
+                    } else {
+                        startSessionCountdown(session.id, timerData.remaining_seconds);
                     }
                 }
             }
@@ -137,6 +141,28 @@ function stopTimerRefresh() {
         clearInterval(timerRefreshInterval);
         timerRefreshInterval = undefined;
     }
+    Object.values(sessionCountdowns).forEach(clearInterval);
+}
+
+function startSessionCountdown(sessionId: number, seconds: number) {
+    if (sessionCountdowns[sessionId]) {
+        clearInterval(sessionCountdowns[sessionId]);
+    }
+    const idx = userSessions.value.findIndex(s => s.id === sessionId);
+    if (idx === -1) return;
+    userSessions.value[idx].remaining_seconds = seconds;
+    if (seconds <= 0) return;
+    sessionCountdowns[sessionId] = setInterval(() => {
+        const i = userSessions.value.findIndex(s => s.id === sessionId);
+        if (i === -1) return;
+        const current = userSessions.value[i].remaining_seconds || 0;
+        if (current > 0) {
+            userSessions.value[i].remaining_seconds = current - 1;
+        } else {
+            clearInterval(sessionCountdowns[sessionId]);
+            delete sessionCountdowns[sessionId];
+        }
+    }, 1000);
 }
 
 const getDifficultyColor = (difficulty: string) => {


### PR DESCRIPTION
## Summary
- add local countdown intervals on OSCE station page to show real-time remaining time
- clear countdown timers when sessions expire or component unmounts

## Testing
- `npm test` *(fails: Test Files 7 failed | 9 passed)*
- `php artisan test` *(fails: Tests: 68 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a52fc08c48832786b01073b2692902