### PR TITLE
fix: make session start time immutable

### DIFF
--- a/webapp/app/Models/OsceSession.php
+++ b/webapp/app/Models/OsceSession.php
@@ -119,8 +119,8 @@ class OsceSession extends Model
         $now = now()->utc();
         $startedAt = $startedBase->utc();
 
-        // Absolute difference in seconds, never negative
-        return max(0, (int) $now->diffInSeconds($startedAt));
+        $elapsed = $startedAt->diffInSeconds($now, false);
+        return max(0, (int) $elapsed);
     }
 
     /**

--- a/webapp/database/migrations/2025_08_19_000007_make_started_at_immutable.php
+++ b/webapp/database/migrations/2025_08_19_000007_make_started_at_immutable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE osce_sessions MODIFY started_at DATETIME NULL");
+        } elseif ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE osce_sessions ALTER COLUMN started_at TYPE timestamp without time zone");
+            DB::statement("ALTER TABLE osce_sessions ALTER COLUMN started_at DROP DEFAULT");
+        }
+
+        DB::table('osce_sessions')
+            ->where('status', 'in_progress')
+            ->whereNull('started_at')
+            ->update(['started_at' => DB::raw('created_at')]);
+    }
+
+    public function down(): void
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'mysql') {
+            DB::statement("ALTER TABLE osce_sessions MODIFY started_at TIMESTAMP NULL");
+        } elseif ($driver === 'pgsql') {
+            DB::statement("ALTER TABLE osce_sessions ALTER COLUMN started_at TYPE timestamp without time zone");
+        }
+    }
+};

--- a/webapp/tests/Feature/StartedAtColumnTest.php
+++ b/webapp/tests/Feature/StartedAtColumnTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class StartedAtColumnTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!file_exists(database_path('database.sqlite'))) {
+            touch(database_path('database.sqlite'));
+        }
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_16_023052_create_osce_sessions_table.php'), '--realpath' => true, '--force' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_18_000001_add_timer_fields_and_indexes_to_osce_sessions_table.php'), '--realpath' => true, '--force' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_19_000007_make_started_at_immutable.php'), '--realpath' => true, '--force' => true]);
+    }
+
+    /** @test */
+    public function started_at_column_has_no_on_update_behavior()
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'sqlite') {
+            $this->markTestSkipped('SQLite driver does not support ON UPDATE');
+        }
+
+        if ($driver === 'mysql') {
+            $result = DB::select("SHOW CREATE TABLE osce_sessions");
+            $create = $result[0]->{'Create Table'} ?? '';
+            $this->assertStringNotContainsString('ON UPDATE', strtoupper($create));
+        } elseif ($driver === 'pgsql') {
+            $result = DB::select("SELECT pg_get_expr(d.adbin, d.adrelid) AS default_expr FROM pg_attrdef d JOIN pg_class t ON d.adrelid = t.oid JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.adnum WHERE t.relname = 'osce_sessions' AND a.attname = 'started_at'");
+            $this->assertEmpty($result, 'started_at should not have a default');
+        }
+    }
+}

--- a/webapp/tests/Feature/TimerResyncTest.php
+++ b/webapp/tests/Feature/TimerResyncTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use App\Models\User;
+use App\Models\OsceCase;
+use App\Models\OsceSession;
+use Carbon\Carbon;
+
+class TimerResyncTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!file_exists(database_path('database.sqlite'))) {
+            touch(database_path('database.sqlite'));
+        }
+        Artisan::call('migrate', ['--path' => database_path('migrations/0001_01_01_000000_create_users_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_16_023044_create_osce_cases_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_16_131415_add_ai_patient_data_to_osce_cases_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_17_000001_add_examination_fields_to_osce_cases_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_16_023052_create_osce_sessions_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_18_000001_add_timer_fields_and_indexes_to_osce_sessions_table.php'), '--realpath' => true]);
+        Artisan::call('migrate', ['--path' => database_path('migrations/2025_08_19_000007_make_started_at_immutable.php'), '--realpath' => true]);
+    }
+
+    /** @test */
+    public function timer_endpoint_decreases_over_time()
+    {
+        Carbon::setTestNow(now());
+        $user = User::factory()->create();
+        $case = OsceCase::create([
+            'title' => 'Test Case',
+            'description' => 'Desc',
+            'difficulty' => 'medium',
+            'duration_minutes' => 15,
+            'scenario' => 'Scenario',
+            'objectives' => 'Objectives',
+            'stations' => [],
+            'checklist' => [],
+            'is_active' => true,
+        ]);
+        $session = OsceSession::create([
+            'user_id' => $user->id,
+            'osce_case_id' => $case->id,
+            'status' => 'in_progress',
+            'started_at' => now()->subMinutes(2),
+        ]);
+
+        $this->actingAs($user);
+        $first = $this->getJson("/api/osce/sessions/{$session->id}/timer")->json();
+        $this->assertEquals(780, $first['remaining_seconds']);
+
+        Carbon::setTestNow(now()->addSeconds(3));
+        $second = $this->getJson("/api/osce/sessions/{$session->id}/timer")->json();
+
+        $this->assertEquals($first['remaining_seconds'] - 3, $second['remaining_seconds']);
+        $this->assertEquals($first['elapsed_seconds'] + 3, $second['elapsed_seconds']);
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `started_at` column is immutable and backfilled
- harden elapsed time calculation against negative drifts
- add regression and schema tests

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test tests/Feature/TimerResyncTest.php tests/Feature/StartedAtColumnTest.php` *(fails: no such table: osce_cases)*

------
https://chatgpt.com/codex/tasks/task_e_68a53e4a0c6c8327a334a6772c60e921