### PR TITLE
Conditionally Hide Pagination on SOAP Board (vibe-kanban)

### DIFF
--- a/webapp/resources/js/pages/Soap/Board.vue
+++ b/webapp/resources/js/pages/Soap/Board.vue
@@ -121,7 +121,7 @@ function rel(t: string): string {
           </Card>
         </div>
 
-        <div class="mt-6">
+        <div class="mt-6" v-if="patients.last_page > 1">
             <Pagination v-slot="{ page }" :total="patients.last_page * 10" :sibling-count="1" show-edges :default-page="patients.current_page">
                 <PaginationContent v-slot="{ items }" class="flex items-center justify-center gap-1">
                     <PaginationFirst :href="patients.links[0].url" />


### PR DESCRIPTION
# PROMPT: Fix or Modify an Existing Feature: SOAP Board Pagination Visibility

## 1. Context & Location

*   **Project folder context**: `/home/bintangputra/osc`
*   **Feature being modified:** The pagination component on the SOAP Patient Board.
*   **Key Files & Code Location:**
    *   Vue Component: `webapp/resources/js/pages/Soap/Board.vue`

---

## 2. Problem Description / Modification Goal

*   **Current Behavior:** The pagination controls are always visible on the `/soap` board, even when there is only one page of patients and no other pages to navigate to. This can be confusing for the user.
*   **Expected Behavior:** The pagination controls should only be rendered and visible if there is more than one page of patient results (`patients.last_page > 1`).
*   **Reason for Change:** To improve the user interface by hiding unnecessary controls, making the page cleaner and more intuitive.

---

## 3. Implementation Details

*   **Current Implementation:** The pagination component is rendered unconditionally within a `div`.

    ```vue
    <div class="mt-6">
        <Pagination v-slot="{ page }" :total="patients.last_page * 10" :sibling-count="1" show-edges :default-page="patients.current_page">
            <PaginationContent v-slot="{ items }" class="flex items-center justify-center gap-1">
                <!-- ... pagination items ... -->
            </PaginationContent>
        </Pagination>
    </div>
    ```

*   **Specified Approach & Required Changes:**
    *   **Approach:** Apply conditional rendering to the pagination's container `div`.
    *   **Changes:**
        1.  In `webapp/resources/js/pages/Soap/Board.vue`, find the `div` that wraps the `<Pagination>` component.
        2.  Add a `v-if="patients.last_page > 1"` directive to this `div` to ensure it only renders when there are multiple pages.

---

## 4. Constraints / Non-Goals

*   **What NOT to change:** The internal logic or appearance of the pagination component itself should not be altered. The change should only affect its visibility.

---

## 5. Acceptance Criteria (verify all)

*   1.  When viewing the SOAP board with a number of patients that fits on a single page, the pagination controls must not be visible.
*   2.  When viewing the SOAP board with enough patients to require multiple pages, the pagination controls must be visible and function correctly.
