### PR TITLE
Refactor Forum Into Twitter-Like Timeline With Inline Comments (vibe-kanban)

### DIFF
--- a/webapp/app/Http/Controllers/CommentController.php
+++ b/webapp/app/Http/Controllers/CommentController.php
@@ -21,7 +21,34 @@ class CommentController extends Controller
             'user_id' => auth()->id(),
         ]);
 
-        return redirect()->route('forum.show', $post);
+        return redirect()->route('forum.index');
+    }
+
+    public function indexApi(Post $post)
+    {
+        $comments = $post->comments()
+            ->with('user')
+            ->oldest()
+            ->paginate(10);
+
+        return CommentResource::collection($comments);
+    }
+
+    public function storeApi(Request $request, Post $post)
+    {
+        $request->validate([
+            'content' => 'required|string',
+        ]);
+
+        $comment = Comment::create([
+            'content' => $request->content,
+            'post_id' => $post->id,
+            'user_id' => auth()->id(),
+        ]);
+
+        $comment->load('user');
+
+        return response()->json(new CommentResource($comment), 201);
     }
 
     public function update(Request $request, Comment $comment)
@@ -34,7 +61,7 @@ class CommentController extends Controller
 
         $comment->update($request->only(['content']));
 
-        return redirect()->route('forum.show', $comment->post);
+        return redirect()->route('forum.index');
     }
 
     public function destroy(Comment $comment)
@@ -44,7 +71,7 @@ class CommentController extends Controller
         $post = $comment->post;
         $comment->delete();
 
-        return redirect()->route('forum.show', $post);
+        return redirect()->route('forum.index');
     }
 }
 

--- a/webapp/app/Http/Controllers/PostController.php
+++ b/webapp/app/Http/Controllers/PostController.php
@@ -19,6 +19,13 @@ class PostController extends Controller
 
         return Inertia::render('Forum/Index', [
             'posts' => ForumPostResource::collection($posts),
+            'auth' => [
+                'user' => auth()->user() ? [
+                    'id' => auth()->user()->id,
+                    'name' => auth()->user()->name,
+                    'avatar' => auth()->user()->avatar,
+                ] : null,
+            ],
         ]);
     }
 

--- a/webapp/app/Http/Controllers/PostController.php
+++ b/webapp/app/Http/Controllers/PostController.php
@@ -35,17 +35,44 @@ class PostController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'title' => 'required|string|max:255',
+            'title' => 'nullable|string|max:255',
             'content' => 'required|string',
         ]);
 
         $post = Post::create([
-            'title' => $request->title,
+            'title' => $request->title ?: '',
             'content' => $request->content,
             'user_id' => auth()->id(),
         ]);
 
-        return redirect()->route('forum.show', $post);
+        return redirect()->route('forum.index');
+    }
+
+    public function indexApi(Request $request)
+    {
+        $posts = Post::with(['user'])
+            ->withCount('comments')
+            ->latest()
+            ->paginate(10);
+
+        return ForumPostResource::collection($posts);
+    }
+
+    public function storeApi(Request $request)
+    {
+        $request->validate([
+            'content' => 'required|string|max:280',
+        ]);
+
+        $post = Post::create([
+            'title' => '', // Empty title for Twitter-like posts
+            'content' => $request->content,
+            'user_id' => auth()->id(),
+        ]);
+
+        $post->load(['user']);
+
+        return response()->json(new ForumPostResource($post), 201);
     }
 
     public function update(Request $request, Post $post)
@@ -53,13 +80,13 @@ class PostController extends Controller
         $this->authorize('update', $post);
 
         $request->validate([
-            'title' => 'required|string|max:255',
+            'title' => 'nullable|string|max:255',
             'content' => 'required|string',
         ]);
 
         $post->update($request->only(['title', 'content']));
 
-        return redirect()->route('forum.show', $post);
+        return redirect()->route('forum.index');
     }
 
     public function destroy(Post $post)

--- a/webapp/resources/js/pages/Forum/Index.vue
+++ b/webapp/resources/js/pages/Forum/Index.vue
@@ -40,6 +40,9 @@ interface Props {
         meta?: any;
         links?: any;
     };
+    auth: {
+        user: User | null;
+    };
 }
 
 const props = defineProps<Props>();
@@ -230,8 +233,9 @@ const getInitials = (name: string) => {
                 <CardContent class="p-4">
                     <div class="flex gap-3">
                         <Avatar class="h-10 w-10 flex-shrink-0">
+                            <AvatarImage :src="props.auth.user?.avatar" />
                             <AvatarFallback>
-                                {{ getInitials('You') }}
+                                {{ props.auth.user?.name ? getInitials(props.auth.user.name) : 'U' }}
                             </AvatarFallback>
                         </Avatar>
                         <div class="flex-1">
@@ -342,8 +346,9 @@ const getInitials = (name: string) => {
                                     <!-- Reply Input -->
                                     <div class="flex gap-3">
                                         <Avatar class="h-8 w-8 flex-shrink-0">
+                                            <AvatarImage :src="props.auth.user?.avatar" />
                                             <AvatarFallback class="text-xs">
-                                                {{ getInitials('You') }}
+                                                {{ props.auth.user?.name ? getInitials(props.auth.user.name) : 'U' }}
                                             </AvatarFallback>
                                         </Avatar>
                                         <div class="flex-1">

--- a/webapp/resources/js/pages/Forum/Index.vue
+++ b/webapp/resources/js/pages/Forum/Index.vue
@@ -1,26 +1,35 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router, useForm } from '@inertiajs/vue3';
+import { Head, router } from '@inertiajs/vue3';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Plus, MessageSquare, User } from 'lucide-vue-next';
-import { ref } from 'vue';
+import { MessageSquare, Heart, Share, Send, Loader2 } from 'lucide-vue-next';
+import { ref, computed, onMounted, nextTick } from 'vue';
+
+interface User {
+    id: number;
+    name: string;
+    avatar?: string;
+}
 
 interface Post {
     id: number;
     title: string;
     content: string;
-    user: {
-        id: number;
-        name: string;
-        avatar?: string;
-    };
+    user: User;
     comments_count: number;
+    created_at: string;
+    formatted_created_at: string;
+}
+
+interface Comment {
+    id: number;
+    content: string;
+    user: User;
     created_at: string;
     formatted_created_at: string;
 }
@@ -42,20 +51,154 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-const showNewPostForm = ref(false);
+// Timeline state
+const posts = ref<Post[]>(props.posts.data);
+const newPostContent = ref('');
+const isPosting = ref(false);
+const loadingMore = ref(false);
+const nextPageUrl = ref(props.posts.links?.next);
 
-const form = useForm({
-    title: '',
-    content: '',
-});
+// Comments state
+const showComments = ref<Record<number, boolean>>({});
+const comments = ref<Record<number, Comment[]>>({});
+const commentInput = ref<Record<number, string>>({});
+const loadingComments = ref<Record<number, boolean>>({});
+const postingComment = ref<Record<number, boolean>>({});
 
-const submitPost = () => {
-    form.post('/forum', {
-        onSuccess: () => {
-            form.reset();
-            showNewPostForm.value = false;
-        },
-    });
+// Character limit for posts (Twitter-like)
+const CHARACTER_LIMIT = 280;
+
+const characterCount = computed(() => newPostContent.value.length);
+const canPost = computed(() => 
+    newPostContent.value.trim().length > 0 && 
+    newPostContent.value.length <= CHARACTER_LIMIT && 
+    !isPosting.value
+);
+
+const submitPost = async () => {
+    if (!canPost.value) return;
+    
+    isPosting.value = true;
+    try {
+        const response = await fetch('/api/forum/posts', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+            },
+            body: JSON.stringify({ content: newPostContent.value })
+        });
+        
+        if (response.ok) {
+            const newPost = await response.json();
+            posts.value.unshift(newPost.data);
+            newPostContent.value = '';
+        }
+    } catch (error) {
+        console.error('Failed to post:', error);
+    } finally {
+        isPosting.value = false;
+    }
+};
+
+const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submitPost();
+    }
+};
+
+const toggleComments = async (postId: number) => {
+    showComments.value[postId] = !showComments.value[postId];
+    
+    // Lazy load comments on first expand
+    if (showComments.value[postId] && !comments.value[postId]) {
+        await loadComments(postId);
+    }
+};
+
+const loadComments = async (postId: number) => {
+    loadingComments.value[postId] = true;
+    try {
+        const response = await fetch(`/api/forum/posts/${postId}/comments`);
+        if (response.ok) {
+            const data = await response.json();
+            comments.value[postId] = data.data;
+        }
+    } catch (error) {
+        console.error('Failed to load comments:', error);
+    } finally {
+        loadingComments.value[postId] = false;
+    }
+};
+
+const submitComment = async (postId: number) => {
+    const content = commentInput.value[postId]?.trim();
+    if (!content || postingComment.value[postId]) return;
+    
+    postingComment.value[postId] = true;
+    try {
+        const response = await fetch(`/api/forum/posts/${postId}/comments`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+            },
+            body: JSON.stringify({ content })
+        });
+        
+        if (response.ok) {
+            const newComment = await response.json();
+            if (!comments.value[postId]) comments.value[postId] = [];
+            comments.value[postId].push(newComment.data);
+            commentInput.value[postId] = '';
+            
+            // Update comments count
+            const post = posts.value.find(p => p.id === postId);
+            if (post) post.comments_count++;
+        }
+    } catch (error) {
+        console.error('Failed to post comment:', error);
+    } finally {
+        postingComment.value[postId] = false;
+    }
+};
+
+const handleCommentKeydown = (event: KeyboardEvent, postId: number) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submitComment(postId);
+    }
+};
+
+const loadMorePosts = async () => {
+    if (!nextPageUrl.value || loadingMore.value) return;
+    
+    loadingMore.value = true;
+    try {
+        const response = await fetch(nextPageUrl.value);
+        if (response.ok) {
+            const data = await response.json();
+            posts.value.push(...data.data);
+            nextPageUrl.value = data.links?.next;
+        }
+    } catch (error) {
+        console.error('Failed to load more posts:', error);
+    } finally {
+        loadingMore.value = false;
+    }
+};
+
+const formatRelativeTime = (timestamp: string) => {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const seconds = Math.floor(diff / 1000);
+    
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+    return `${Math.floor(seconds / 86400)}d`;
 };
 
 const getInitials = (name: string) => {
@@ -69,118 +212,215 @@ const getInitials = (name: string) => {
 </script>
 
 <template>
-
     <Head title="Forum" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 overflow-x-auto">
-            <!-- Header with New Post Button -->
+            <!-- Header -->
             <div class="flex justify-between items-center">
                 <div>
-                    <h1 class="text-2xl font-semibold">Forum</h1>
-                    <p class="text-muted-foreground">Share and discuss with the community</p>
+                    <h1 class="text-2xl font-semibold">Timeline</h1>
+                    <p class="text-muted-foreground">What's happening?</p>
                 </div>
-                <Button @click="showNewPostForm = !showNewPostForm" class="gap-2">
-                    <Plus class="w-4 h-4" />
-                    New Post
-                </Button>
             </div>
 
-            <!-- New Post Form -->
-            <Card v-if="showNewPostForm" class="border-sidebar-border/70 dark:border-sidebar-border">
-                <CardHeader>
-                    <CardTitle>Create New Post</CardTitle>
-                    <CardDescription>Share something with the community</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <form @submit.prevent="submitPost" class="space-y-4">
-                        <div>
-                            <Input v-model="form.title" placeholder="Post title..." required
-                                :disabled="form.processing" />
+            <!-- Composer -->
+            <Card class="border-sidebar-border/70 dark:border-sidebar-border">
+                <CardContent class="p-4">
+                    <div class="flex gap-3">
+                        <Avatar class="h-10 w-10 flex-shrink-0">
+                            <AvatarFallback>
+                                {{ getInitials('You') }}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div class="flex-1">
+                            <Textarea 
+                                v-model="newPostContent"
+                                placeholder="What's happening?"
+                                class="resize-none border-none shadow-none p-0 text-lg placeholder:text-muted-foreground focus-visible:ring-0"
+                                rows="3"
+                                @keydown="handleKeydown"
+                                :disabled="isPosting"
+                                :maxlength="CHARACTER_LIMIT"
+                            />
+                            <div class="flex justify-between items-center mt-3">
+                                <div class="flex items-center gap-2 text-sm">
+                                    <span :class="{
+                                        'text-red-500': characterCount > CHARACTER_LIMIT,
+                                        'text-yellow-500': characterCount > CHARACTER_LIMIT * 0.8,
+                                        'text-muted-foreground': characterCount <= CHARACTER_LIMIT * 0.8
+                                    }">
+                                        {{ characterCount }}/{{ CHARACTER_LIMIT }}
+                                    </span>
+                                </div>
+                                <Button 
+                                    @click="submitPost"
+                                    :disabled="!canPost"
+                                    size="sm"
+                                    class="gap-2"
+                                >
+                                    <Loader2 v-if="isPosting" class="w-4 h-4 animate-spin" />
+                                    <Send v-else class="w-4 h-4" />
+                                    {{ isPosting ? 'Posting...' : 'Post' }}
+                                </Button>
+                            </div>
+                            <p class="text-xs text-muted-foreground mt-2">
+                                Press Enter to post, Shift+Enter for new line
+                            </p>
                         </div>
-                        <div>
-                            <Textarea v-model="form.content" placeholder="What's on your mind?" rows="4" required
-                                :disabled="form.processing" />
-                        </div>
-                        <div class="flex gap-2">
-                            <Button type="submit" :disabled="form.processing">
-                                {{ form.processing ? 'Publishing...' : 'Publish Post' }}
-                            </Button>
-                            <Button type="button" variant="outline" @click="showNewPostForm = false"
-                                :disabled="form.processing">
-                                Cancel
-                            </Button>
-                        </div>
-                    </form>
+                    </div>
                 </CardContent>
             </Card>
 
-            <!-- Posts List -->
-            <div
-                class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                <div class="p-6">
-                    <div v-if="posts.data.length === 0" class="text-center py-12">
+            <!-- Timeline -->
+            <div class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
+                <div class="divide-y divide-border">
+                    <div v-if="posts.length === 0" class="text-center py-12 px-6">
                         <MessageSquare class="mx-auto h-12 w-12 text-muted-foreground mb-4" />
                         <h3 class="text-lg font-medium">No posts yet</h3>
-                        <p class="text-muted-foreground mb-4">Be the first to start a conversation!</p>
-                        <Button @click="showNewPostForm = true" class="gap-2">
-                            <Plus class="w-4 h-4" />
-                            Create First Post
-                        </Button>
+                        <p class="text-muted-foreground">Be the first to start a conversation!</p>
                     </div>
 
-                    <div v-else class="space-y-4">
-                        <Card v-for="post in posts.data" :key="post.id"
-                            class="border-sidebar-border/70 dark:border-sidebar-border hover:bg-muted/50 transition-colors cursor-pointer"
-                            @click="router.visit(`/forum/${post.id}`)">
-                            <CardContent class="p-6">
-                                <div class="flex gap-4">
-                                    <Avatar class="h-10 w-10 flex-shrink-0">
-                                        <AvatarImage :src="post.user?.avatar" />
-                                        <AvatarFallback>
-                                            {{ post.user?.name ? getInitials(post.user.name) : '?' }}
-                                        </AvatarFallback>
-                                    </Avatar>
+                    <!-- Timeline Posts -->
+                    <article 
+                        v-for="post in posts" 
+                        :key="post.id" 
+                        class="p-4 hover:bg-muted/50 transition-colors"
+                    >
+                        <div class="flex gap-3">
+                            <Avatar class="h-10 w-10 flex-shrink-0">
+                                <AvatarImage :src="post.user?.avatar" />
+                                <AvatarFallback>
+                                    {{ post.user?.name ? getInitials(post.user.name) : '?' }}
+                                </AvatarFallback>
+                            </Avatar>
 
-                                    <div class="flex-1 min-w-0">
-                                        <div class="flex items-center gap-2 mb-2">
-                                            <span class="font-medium">{{ post.user?.name || 'Unknown User' }}</span>
-                                            <span class="text-muted-foreground text-sm">
-                                                {{ post.formatted_created_at }}
-                                            </span>
+                            <div class="flex-1 min-w-0">
+                                <!-- Post Header -->
+                                <div class="flex items-center gap-2 mb-1">
+                                    <span class="font-semibold">{{ post.user?.name || 'Unknown User' }}</span>
+                                    <span class="text-muted-foreground text-sm">·</span>
+                                    <span class="text-muted-foreground text-sm" :title="post.created_at">
+                                        {{ formatRelativeTime(post.created_at) }}
+                                    </span>
+                                </div>
+
+                                <!-- Post Content -->
+                                <div class="mb-3">
+                                    <p class="text-sm leading-relaxed whitespace-pre-wrap">{{ post.content }}</p>
+                                </div>
+
+                                <!-- Post Actions -->
+                                <div class="flex items-center gap-6 text-muted-foreground">
+                                    <button 
+                                        @click="toggleComments(post.id)"
+                                        class="flex items-center gap-1 hover:text-blue-500 transition-colors group"
+                                        :class="{ 'text-blue-500': showComments[post.id] }"
+                                    >
+                                        <div class="p-2 rounded-full group-hover:bg-blue-500/10 transition-colors">
+                                            <MessageSquare class="w-4 h-4" />
                                         </div>
+                                        <span class="text-sm">{{ post.comments_count }}</span>
+                                    </button>
+                                    
+                                    <button class="flex items-center gap-1 hover:text-red-500 transition-colors group">
+                                        <div class="p-2 rounded-full group-hover:bg-red-500/10 transition-colors">
+                                            <Heart class="w-4 h-4" />
+                                        </div>
+                                    </button>
+                                    
+                                    <button class="flex items-center gap-1 hover:text-green-500 transition-colors group">
+                                        <div class="p-2 rounded-full group-hover:bg-green-500/10 transition-colors">
+                                            <Share class="w-4 h-4" />
+                                        </div>
+                                    </button>
+                                </div>
 
-                                        <h3 class="text-lg font-semibold mb-2 hover:text-primary transition-colors">
-                                            {{ post.title }}
-                                        </h3>
+                                <!-- Inline Comments Thread -->
+                                <div v-if="showComments[post.id]" class="mt-4 space-y-3">
+                                    <!-- Reply Input -->
+                                    <div class="flex gap-3">
+                                        <Avatar class="h-8 w-8 flex-shrink-0">
+                                            <AvatarFallback class="text-xs">
+                                                {{ getInitials('You') }}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div class="flex-1">
+                                            <Textarea 
+                                                v-model="commentInput[post.id]"
+                                                placeholder="Post your reply"
+                                                class="resize-none min-h-[80px] text-sm"
+                                                rows="2"
+                                                @keydown="(e) => handleCommentKeydown(e, post.id)"
+                                                :disabled="postingComment[post.id]"
+                                            />
+                                            <div class="flex justify-between items-center mt-2">
+                                                <p class="text-xs text-muted-foreground">
+                                                    Press Enter to reply, Shift+Enter for new line
+                                                </p>
+                                                <Button 
+                                                    @click="submitComment(post.id)"
+                                                    size="sm"
+                                                    :disabled="!commentInput[post.id]?.trim() || postingComment[post.id]"
+                                                    class="gap-1"
+                                                >
+                                                    <Loader2 v-if="postingComment[post.id]" class="w-3 h-3 animate-spin" />
+                                                    <Send v-else class="w-3 h-3" />
+                                                    Reply
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    </div>
 
-                                        <p class="text-muted-foreground line-clamp-3 mb-3">
-                                            {{ post.content }}
-                                        </p>
-
-                                        <div class="flex items-center gap-2">
-                                            <Badge variant="secondary" class="gap-1">
-                                                <MessageSquare class="w-3 h-3" />
-                                                {{ post.comments_count }}
-                                                {{ post.comments_count === 1 ? 'comment' : 'comments' }}
-                                            </Badge>
+                                    <!-- Comments List -->
+                                    <div v-if="loadingComments[post.id]" class="flex items-center justify-center py-4">
+                                        <Loader2 class="w-4 h-4 animate-spin" />
+                                        <span class="ml-2 text-sm text-muted-foreground">Loading comments...</span>
+                                    </div>
+                                    
+                                    <div v-else-if="comments[post.id]" class="space-y-3">
+                                        <div 
+                                            v-for="comment in comments[post.id]" 
+                                            :key="comment.id"
+                                            class="flex gap-3 pl-0"
+                                        >
+                                            <Avatar class="h-8 w-8 flex-shrink-0">
+                                                <AvatarImage :src="comment.user?.avatar" />
+                                                <AvatarFallback class="text-xs">
+                                                    {{ comment.user?.name ? getInitials(comment.user.name) : '?' }}
+                                                </AvatarFallback>
+                                            </Avatar>
+                                            <div class="flex-1 min-w-0">
+                                                <div class="flex items-center gap-2 mb-1">
+                                                    <span class="font-medium text-sm">{{ comment.user?.name || 'Unknown User' }}</span>
+                                                    <span class="text-muted-foreground text-xs">·</span>
+                                                    <span class="text-muted-foreground text-xs" :title="comment.created_at">
+                                                        {{ formatRelativeTime(comment.created_at) }}
+                                                    </span>
+                                                </div>
+                                                <p class="text-sm leading-relaxed whitespace-pre-wrap">{{ comment.content }}</p>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </CardContent>
-                        </Card>
-                    </div>
+                            </div>
+                        </div>
+                    </article>
+                </div>
+
+                <!-- Load More Button -->
+                <div v-if="nextPageUrl" class="p-4 border-t">
+                    <Button 
+                        @click="loadMorePosts"
+                        :disabled="loadingMore"
+                        variant="outline"
+                        class="w-full gap-2"
+                    >
+                        <Loader2 v-if="loadingMore" class="w-4 h-4 animate-spin" />
+                        {{ loadingMore ? 'Loading...' : 'Load more posts' }}
+                    </Button>
                 </div>
             </div>
         </div>
     </AppLayout>
 </template>
-
-<style scoped>
-.line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-</style>

--- a/webapp/resources/js/pages/Forum/Index.vue
+++ b/webapp/resources/js/pages/Forum/Index.vue
@@ -91,7 +91,8 @@ const submitPost = async () => {
         
         if (response.ok) {
             const newPost = await response.json();
-            posts.value.unshift(newPost.data);
+            // Single resource doesn't have .data wrapper, collections do
+            posts.value.unshift(newPost);
             newPostContent.value = '';
         }
     } catch (error) {
@@ -150,7 +151,7 @@ const submitComment = async (postId: number) => {
         if (response.ok) {
             const newComment = await response.json();
             if (!comments.value[postId]) comments.value[postId] = [];
-            comments.value[postId].push(newComment.data);
+            comments.value[postId].push(newComment);
             commentInput.value[postId] = '';
             
             // Update comments count

--- a/webapp/routes/web.php
+++ b/webapp/routes/web.php
@@ -64,6 +64,14 @@ Route::middleware([
 	Route::put('comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
 	Route::delete('comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
 
+	// JSON API routes for timeline
+	Route::prefix('api/forum')->group(function () {
+		Route::get('posts', [PostController::class, 'indexApi'])->name('api.forum.posts.index');
+		Route::post('posts', [PostController::class, 'storeApi'])->name('api.forum.posts.store');
+		Route::get('posts/{post}/comments', [CommentController::class, 'indexApi'])->name('api.forum.comments.index');
+		Route::post('posts/{post}/comments', [CommentController::class, 'storeApi'])->name('api.forum.comments.store');
+	});
+
 	// SOAP routes
 	// NEW PAGES
 	Route::get('soap', [SoapBoardController::class, 'index'])->name('soap.board');


### PR DESCRIPTION
## Purpose

- Convert Forum into a single-page timeline with inline comments (no separate “show post” page).
- Use a textarea composer; post/send on Enter; Shift+Enter inserts a newline.
- Show and add comments inline under each post without navigating away.

## Scope

- **Frontend**: Replace Forum index/show flow with one timeline page; inline comments; Enter-to-post UX.
- **Backend**: Add lightweight JSON endpoints for posts and comments to support inline updates; keep existing routes for compatibility.
- **Data**: No schema changes; reuse posts and comments tables and resources.

## Code References

- Pages: `webapp/resources/js/pages/Forum/Index.vue`, `Forum/Show.vue`, `Forum.vue` (consolidate to a single Timeline page)
- Controllers: `webapp/app/Http/Controllers/PostController.php`, `CommentController.php`
- Resources: `webapp/app/Http/Resources/ForumPostResource.php`, `CommentResource.php`
- Routes: `webapp/routes/web.php` (forum + comment routes)

## UI Behavior

- **Timeline**:
    - Top composer: single textarea with placeholder “What’s happening?”; Enter submits; Shift+Enter = newline; disabled when empty; show remaining count (e.g., 280).
    - Posts render newest-first; show avatar, name, content, relative time, and counts.
    - Actions: Reply (toggles inline thread), Like (placeholder), Share (optional copy link).
- **Inline comments**:
    - Clicking Reply reveals a small textarea under the post; Enter submits; Shift+Enter newline.
    - Displays the thread (newest-first or oldest-first, pick one; default oldest-first); no page navigation.
    - “View N comments” toggles the thread; lazy loads on first expand.
- **Loading**:
    - Infinite scroll or “Load more” button at bottom; uses cursor/next page.
    - Optimistic append for new post/comment; fallback to server response on success.

## Backend Changes

- **Controllers (add JSON methods; keep existing Inertia responses)**:
    - `PostController@indexApi`: returns paginated posts (no comments), each with counts and basic author data.
    - `PostController@storeApi`: validates, creates post, returns 201 + `ForumPostResource`.
    - `CommentController@indexApi`: returns post’s comments (paginated or capped to 10 with “load more”).
    - `CommentController@storeApi`: validates, creates comment, returns 201 + `CommentResource`.
- **Preserve existing methods but adjust redirects for better UX**:
    - `PostController@store` (web): redirect back to `forum.index` instead of `forum.show` (to avoid opening a different page).
    - `CommentController@store` (web): redirect back to `forum.index` as well.
- **Resources**:
    - Ensure `ForumPostResource` includes `comments_count`, `formatted_created_at`, and user meta needed by the timeline.
    - Ensure `CommentResource` includes `formatted_created_at` and user.

## Routes

- **Keep existing**:
    - `GET /forum` → `PostController@index` (Inertia timeline)
    - `POST /forum` → `PostController@store`
    - `GET /forum/{post}` → deprecated for UX; keep for compatibility, link out removed from UI
    - `POST /forum/{post}/comments` → `CommentController@store`
- **Add JSON API**:
    - `GET /api/forum/posts` → `PostController@indexApi`
    - `POST /api/forum/posts` → `PostController@storeApi`
    - `GET /api/forum/posts/{post}/comments` → `CommentController@indexApi`
    - `POST /api/forum/posts/{post}/comments` → `CommentController@storeApi`

## Frontend Changes

- **New/updated page**: `resources/js/pages/Forum/Timeline.vue` (or repurpose `Forum/Index.vue`) with:
    - **Composer**:
    - `<Textarea>` with keydown handler: Enter submits unless `event.shiftKey`.
    - Character limit (e.g., 280) with live count; disable when over limit or empty; show subtle helper text.
    - Submit via `fetch('/api/forum/posts')` or Inertia `router.post` to JSON endpoint; optimistic append.
- **Timeline list**:
    - Fetch initial posts from Inertia prop (server-rendered) for fast TTFB.
    - “Load more” fetches from `GET /api/forum/posts?page=N` and appends.
    - Remove navigation on card click; no `router.visit('/forum/{id}')`.
- **Inline comments**:
    - Each post card has a Reply button: toggles a local `showComments[post.id]` and `commentInput[post.id]`.
    - On first expand, lazy fetch `GET /api/forum/posts/{post}/comments` and render.
    - Comment textarea: Enter-to-post; Shift+Enter newline; submit to `POST /api/forum/posts/{post}/comments`; optimistic append.
    - Show “View more comments” to paginate thread.
- **Remove “No different page” navigation**:
    - Delete “open post” click handlers and breadcrumbs to `/forum/{post}`.
    - Optionally keep a “Copy link” action for sharing.

## Validation & UX Rules

- **Post create**:
    - Required: content (non-empty, trimmed); optional: title removed or hidden for Twitter-like UX.
    - If title kept, default to empty and hide in UI; backend can accept nullable title.
- **Comment create**:
    - Required: content (non-empty, trimmed).
- **Keyboard**:
    - Enter = submit; Shift+Enter = newline for both composer and reply boxes.
- **Errors**:
    - Show inline error toasts; keep content in textarea; focus stays in place.
- **Performance**:
    - Avoid loading all comments with post list; lazy-load on expand.
    - Use pagination for both posts and comments.

## Acceptance Criteria

- Visiting `/forum` shows a Twitter-like timeline with a top composer.
- Enter posts a new status; Shift+Enter inserts newline; character limit enforced.
- Clicking Reply reveals an inline comments thread; entering a comment and pressing Enter posts it without page navigation.
- Comments load lazily; expanding and posting does not navigate.
- “Show Post” page is no longer used from the UI; all interactions remain on `/forum`.
- Scrolling loads more posts; appends seamlessly without page reload.
- All actions reflect immediately (optimistic update) and reconcile with server results.

## Test Plan

- **Backend (Feature)**:
    - `GET /api/forum/posts` returns paginated list with counts and user data.
    - `POST /api/forum/posts` with valid content returns 201 and new post resource; invalid returns 422.
    - `GET /api/forum/posts/{post}/comments` returns list with user data.
    - `POST /api/forum/posts/{post}/comments` creates and returns 201; invalid returns 422.
- **Frontend (Manual/Integration)**:
    - Composer: Enter submits; Shift+Enter newline; empty disabled; over limit disabled.
    - Reply: Inline textarea opens; Enter submits; thread updates without navigation; “Load more” works.
    - No navigation occurs to `/forum/{id}` from any click within the timeline.

## Constraints

- No schema changes; reuse existing models/resources.
- Keep existing routes for compatibility; remove “Show” navigation from UI.
- Avoid third-party UI libs beyond what’s already used.

## Options

- Optional: hide post “title” entirely in UI; accept backend changes to make title nullable and defaulted.
- Optional: relative timestamps on client; retain absolute in hover title.