### PR TITLE
Fix Tiptap/NOVEL Vue editor crashing on HTML input by normalizing to JSON and enforcing consistent serialization in Laravel + Vue (Inertia) Features edit flow — detect legacy HTML, convert to Tiptap JSON on load, save as JSON going forward, and ensure backend casts/validation support arrays. (vibe-kanban)

### DIFF
--- a/webapp/app/Http/Controllers/SoapNoteController.php
+++ b/webapp/app/Http/Controllers/SoapNoteController.php
@@ -14,18 +14,19 @@ class SoapNoteController extends Controller
     public function store(Request $request, Patient $patient): RedirectResponse
     {
         $validated = $request->validate([
-            'subjective' => 'nullable', // Allow both string and array (JSON)
-            'objective' => 'nullable', 
-            'assessment' => 'nullable',
-            'plan' => 'nullable',
+            'subjective' => 'nullable|array',
+            'objective' => 'nullable|array',
+            'assessment' => 'nullable|array',
+            'plan' => 'nullable|array',
         ]);
 
-        // Ensure no null values are passed to database (NOT NULL constraint)
+        // Ensure consistent JSON structure for rich-text fields (TipTap doc)
+        $emptyDoc = ['type' => 'doc', 'content' => [['type' => 'paragraph']]];
         $cleanedData = [
-            'subjective' => $validated['subjective'] ?? '',
-            'objective' => $validated['objective'] ?? '',
-            'assessment' => $validated['assessment'] ?? '',
-            'plan' => $validated['plan'] ?? '',
+            'subjective' => $validated['subjective'] ?? $emptyDoc,
+            'objective' => $validated['objective'] ?? $emptyDoc,
+            'assessment' => $validated['assessment'] ?? $emptyDoc,
+            'plan' => $validated['plan'] ?? $emptyDoc,
             'author_id' => Auth::id(),
             'state' => 'draft',
         ];
@@ -40,18 +41,19 @@ class SoapNoteController extends Controller
         $this->authorize('update', $note);
 
         $validated = $request->validate([
-            'subjective' => 'nullable', // Allow both string and array (JSON)
-            'objective' => 'nullable', 
-            'assessment' => 'nullable',
-            'plan' => 'nullable',
+            'subjective' => 'nullable|array',
+            'objective' => 'nullable|array',
+            'assessment' => 'nullable|array',
+            'plan' => 'nullable|array',
         ]);
 
-        // Ensure no null values are passed to database (NOT NULL constraint)
+        // Ensure consistent JSON structure for rich-text fields (TipTap doc)
+        $emptyDoc = ['type' => 'doc', 'content' => [['type' => 'paragraph']]];
         $cleanedData = [
-            'subjective' => $validated['subjective'] ?? '',
-            'objective' => $validated['objective'] ?? '',
-            'assessment' => $validated['assessment'] ?? '',
-            'plan' => $validated['plan'] ?? '',
+            'subjective' => $validated['subjective'] ?? $emptyDoc,
+            'objective' => $validated['objective'] ?? $emptyDoc,
+            'assessment' => $validated['assessment'] ?? $emptyDoc,
+            'plan' => $validated['plan'] ?? $emptyDoc,
         ];
 
         $note->update($cleanedData);

--- a/webapp/app/Models/SoapNote.php
+++ b/webapp/app/Models/SoapNote.php
@@ -26,12 +26,11 @@ class SoapNote extends Model
 
     protected $casts = [
         'finalized_at' => 'datetime',
-        // Temporarily removed array casting to fix NOT NULL constraint
-        // Will add back once basic functionality works
-        // 'subjective' => 'array',
-        // 'objective' => 'array', 
-        // 'assessment' => 'array',
-        // 'plan' => 'array',
+        // Store TipTap JSON as arrays; Eloquent serializes to JSON strings in DB
+        'subjective' => 'array',
+        'objective' => 'array', 
+        'assessment' => 'array',
+        'plan' => 'array',
     ];
 
     public function patient(): BelongsTo

--- a/webapp/resources/js/components/SoapNovelEditorClean.vue
+++ b/webapp/resources/js/components/SoapNovelEditorClean.vue
@@ -2,6 +2,7 @@
 import { ref, watch, onMounted, nextTick } from 'vue';
 import { Editor } from 'novel-vue';
 import axios from 'axios';
+import { toTiptapJSON, emptyDoc } from '@/utils/richtext';
 
 interface Props {
   modelValue: any;
@@ -28,50 +29,34 @@ const emit = defineEmits<Emits>();
 const editorRef = ref(null);
 const uploading = ref(false);
 const isReady = ref(false);
-const editorContent = ref('');
+// Keep source of truth minimal; we normalize to JSON for the editor and emit JSON on updates
+const initialValue = ref<any>(emptyDoc());
 
 // Initialize content from props
 onMounted(async () => {
   await nextTick();
   isReady.value = true;
-  // Only set content if it's a valid HTML string
-  if (typeof props.modelValue === 'string' && props.modelValue) {
-    editorContent.value = props.modelValue;
-  }
-  
+  initialValue.value = toTiptapJSON(props.modelValue) || emptyDoc();
   // Clear any localStorage that might contain demo content
   if (typeof window !== 'undefined') {
     try {
-      // Clear any Novel editor storage
       Object.keys(localStorage).forEach(key => {
         if (key.includes('novel') || key.includes('editor')) {
           localStorage.removeItem(key);
         }
       });
-    } catch (e) {
-      // Ignore localStorage errors
+    } catch {
+      // ignore
     }
   }
 });
 
-// Watch for external model value changes - only update if it's different HTML
+// Watch for external model value changes and re-normalize to JSON
 watch(() => props.modelValue, (newValue) => {
-  if (typeof newValue === 'string' && newValue !== editorContent.value) {
-    editorContent.value = newValue;
-  }
+  initialValue.value = toTiptapJSON(newValue) || emptyDoc();
 }, { deep: true });
 
-// Helper to convert content for internal storage - keep as HTML string
-const getContentAsString = (content: any): string => {
-  if (!content) return '';
-  if (typeof content === 'string') return content;
-  if (typeof content === 'object') {
-    // If it's TipTap JSON, ignore it for display purposes
-    // We only store HTML strings internally
-    return '';
-  }
-  return String(content);
-};
+// Removed HTML-centric storage; we normalize to JSON only
 
 // Handle image uploads
 const handleImageUpload = async (file: File): Promise<string> => {
@@ -103,34 +88,32 @@ const handleImageUpload = async (file: File): Promise<string> => {
   }
 };
 
-// Handle content changes - always output HTML string
+// Handle content changes - always emit TipTap JSON
 const handleUpdate = (editor: any) => {
-  let htmlContent = '';
-  
   try {
+    if (editor && typeof editor.getJSON === 'function') {
+      emit('update:modelValue', editor.getJSON());
+      return;
+    }
+    if (editor && typeof editor.getHTML === 'function') {
+      // Fallback: convert editor HTML to TipTap JSON via Novel internals
+      // Novel will pass the new state again, but we still guard
+      emit('update:modelValue', toTiptapJSON(editor.getHTML()));
+      return;
+    }
     if (typeof editor === 'string') {
-      htmlContent = editor;
-    } else if (editor && typeof editor.getHTML === 'function') {
-      htmlContent = editor.getHTML();
-    } else if (editor && editor.content) {
-      // If it's a TipTap JSON object, try to convert to HTML
-      if (typeof editor.content === 'object') {
-        // For now, emit empty HTML if we get JSON
-        htmlContent = '';
-      } else {
-        htmlContent = String(editor.content);
-      }
+      emit('update:modelValue', toTiptapJSON(editor));
+      return;
+    }
+    if (editor && editor.content) {
+      // If raw content provided
+      emit('update:modelValue', toTiptapJSON(editor.content));
+      return;
     }
   } catch (error) {
-    console.warn('Error handling editor update:', error);
-    htmlContent = '';
+    console.warn('Error handling editor update, defaulting to empty doc:', error);
+    emit('update:modelValue', emptyDoc());
   }
-  
-  // Update local content state
-  editorContent.value = htmlContent;
-  
-  // Always emit HTML string, never JSON
-  emit('update:modelValue', htmlContent);
 };
 
 // Handle blur
@@ -138,51 +121,9 @@ const handleBlur = () => {
   emit('blur');
 };
 
-// Convert model value for Novel editor input - must return TipTap JSON format
+// Convert model value for Novel editor input - return TipTap JSON format
 const getEditorValue = () => {
-  if (!props.modelValue) {
-    return {
-      type: 'doc',
-      content: []
-    };
-  }
-  
-  if (typeof props.modelValue === 'string') {
-    if (props.modelValue.trim() === '') {
-      return {
-        type: 'doc',
-        content: []
-      };
-    }
-    
-    // If it's HTML string (contains < and >), let Novel Vue parse it by returning the HTML directly
-    // Novel Vue will automatically convert HTML strings to TipTap JSON internally
-    if (props.modelValue.includes('<') && props.modelValue.includes('>')) {
-      return props.modelValue; // Novel Vue will convert HTML to TipTap JSON
-    } else {
-      // Plain text - wrap in paragraph
-      return {
-        type: 'doc',
-        content: [{
-          type: 'paragraph',
-          content: [{
-            type: 'text',
-            text: props.modelValue
-          }]
-        }]
-      };
-    }
-  }
-  
-  // If it's already an object (TipTap JSON), use it directly
-  if (typeof props.modelValue === 'object') {
-    return props.modelValue;
-  }
-  
-  return {
-    type: 'doc',
-    content: []
-  };
+  return initialValue.value || emptyDoc();
 };
 </script>
 

--- a/webapp/resources/js/pages/Soap/Page.vue
+++ b/webapp/resources/js/pages/Soap/Page.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import SoapNovelEditorClean from '@/components/SoapNovelEditorClean.vue';
 import { sanitizeHtml, stripHtml } from '@/utils/sanitize';
+import { emptyDoc, toHTML, hasEditorContent } from '@/utils/richtext';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -33,17 +34,17 @@ const editingNoteId = ref<number | null>(null);
 const isDirty = ref(false);
 
 const form = useForm({
-  subjective: '',
-  objective: '',
-  assessment: '',
-  plan: '',
+  subjective: emptyDoc(),
+  objective: emptyDoc(),
+  assessment: emptyDoc(),
+  plan: emptyDoc(),
 });
 
 const editForm = useForm({
-  subjective: '',
-  objective: '',
-  assessment: '',
-  plan: '',
+  subjective: emptyDoc(),
+  objective: emptyDoc(),
+  assessment: emptyDoc(),
+  plan: emptyDoc(),
 });
 
 watch(() => props.newNoteId, (newId) => {
@@ -80,8 +81,8 @@ const save = () => {
     noteId: noteId.value
   });
 
-  // Check if form has any content
-  const hasContent = form.subjective || form.objective || form.assessment || form.plan;
+  // Check if form has any content (robust for TipTap JSON)
+  const hasContent = hasEditorContent(form.subjective) || hasEditorContent(form.objective) || hasEditorContent(form.assessment) || hasEditorContent(form.plan);
   if (!hasContent) {
     saveStatus.value = 'Please add some content before saving';
     setTimeout(() => saveStatus.value = '', 3000);
@@ -227,45 +228,16 @@ function rel(t: string): string {
   return `${Math.floor(d / 86400)}d ago`;
 }
 
-// Helper function to convert TipTap JSON to HTML for display
-const convertJsonToHtml = (content: any): string => {
-  if (!content) return '';
-  if (typeof content === 'string') {
-    // If it's already HTML, return as-is
-    return content;
-  }
-  try {
-    const extensions = [
-      StarterKit,
-      Underline,
-      Image.configure({
-        HTMLAttributes: {
-          class: 'rounded-lg border border-gray-300 max-w-full h-auto',
-        },
-      }),
-      Link.configure({
-        openOnClick: false,
-        HTMLAttributes: {
-          class: 'text-blue-600 underline cursor-pointer',
-        },
-      }),
-    ];
-    return generateHTML(content, extensions);
-  } catch (error) {
-    console.warn('Failed to convert JSON to HTML:', error);
-    return '';
-  }
-};
+// Convert mixed input (HTML or TipTap JSON) to HTML for display
+const convertJsonToHtml = (content: any): string => toHTML(content);
 
 // Helper function to get text preview for timeline
 const getTextPreview = (content: any): string => {
   if (!content) return 'Empty';
   
-  // If it's HTML, strip tags for preview
-  let text = String(content);
-  if (text.includes('<')) {
-    text = stripHtml(text);
-  }
+  // Normalize to HTML then strip tags for preview
+  const html = toHTML(content);
+  let text = stripHtml(html);
   
   const preview = text.substring(0, 120);
   return preview || 'Empty';
@@ -449,10 +421,10 @@ onUnmounted(() => {
                   <details>
                     <summary>{{ getTextPreview(note.subjective) }}...</summary>
                     <div class="mt-4 space-y-2">
-                      <div><strong>Subjective:</strong> <div v-html="sanitizeHtml(note.subjective || '')" class="prose prose-sm max-w-none"></div></div>
-                      <div><strong>Objective:</strong> <div v-html="sanitizeHtml(note.objective || '')" class="prose prose-sm max-w-none"></div></div>
-                      <div><strong>Assessment:</strong> <div v-html="sanitizeHtml(note.assessment || '')" class="prose prose-sm max-w-none"></div></div>
-                      <div><strong>Plan:</strong> <div v-html="sanitizeHtml(note.plan || '')" class="prose prose-sm max-w-none"></div></div>
+                      <div><strong>Subjective:</strong> <div v-html="sanitizeHtml(convertJsonToHtml(note.subjective))" class="prose prose-sm max-w-none"></div></div>
+                      <div><strong>Objective:</strong> <div v-html="sanitizeHtml(convertJsonToHtml(note.objective))" class="prose prose-sm max-w-none"></div></div>
+                      <div><strong>Assessment:</strong> <div v-html="sanitizeHtml(convertJsonToHtml(note.assessment))" class="prose prose-sm max-w-none"></div></div>
+                      <div><strong>Plan:</strong> <div v-html="sanitizeHtml(convertJsonToHtml(note.plan))" class="prose prose-sm max-w-none"></div></div>
                     </div>
                   </details>
                   <!-- Edit button -->

--- a/webapp/resources/js/utils/richtext.ts
+++ b/webapp/resources/js/utils/richtext.ts
@@ -1,0 +1,81 @@
+import { generateJSON, generateHTML } from '@tiptap/html'
+import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+import Link from '@tiptap/extension-link'
+import Underline from '@tiptap/extension-underline'
+
+// Shared TipTap extensions configuration used for HTML/JSON conversion
+export const tiptapExtensions = [
+  StarterKit,
+  Underline,
+  Image.configure({
+    HTMLAttributes: {
+      class: 'rounded-lg border border-gray-300 max-w-full h-auto',
+    },
+  }),
+  Link.configure({
+    openOnClick: false,
+    HTMLAttributes: {
+      class: 'text-blue-600 underline cursor-pointer',
+    },
+  }),
+]
+
+export function emptyDoc() {
+  return { type: 'doc', content: [{ type: 'paragraph' }] }
+}
+
+export function isJSONLike(v: unknown): boolean {
+  if (v && typeof v === 'object') return true
+  if (typeof v !== 'string') return false
+  const s = v.trim()
+  if (!(s.startsWith('{') || s.startsWith('['))) return false
+  try {
+    JSON.parse(s)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function isHTMLLike(v: unknown): boolean {
+  return typeof v === 'string' && /<\w+[\s>]/.test(v)
+}
+
+export function toTiptapJSON(input: unknown): any {
+  try {
+    if (input && typeof input === 'object') return input
+    if (isJSONLike(input)) return JSON.parse(input as string)
+    if (isHTMLLike(input)) return generateJSON(input as string, tiptapExtensions)
+    return emptyDoc()
+  } catch (e) {
+    console.warn('toTiptapJSON fallback due to error:', e)
+    return emptyDoc()
+  }
+}
+
+export function toHTML(input: unknown): string {
+  try {
+    if (!input) return ''
+    if (typeof input === 'string') return input
+    // assume TipTap JSON
+    return generateHTML(input as any, tiptapExtensions)
+  } catch (e) {
+    console.warn('toHTML fallback due to error:', e)
+    return ''
+  }
+}
+
+export function hasEditorContent(input: unknown): boolean {
+  try {
+    const json = toTiptapJSON(input)
+    if (!json || typeof json !== 'object') return false
+    if (json.type !== 'doc') return false
+    const content = Array.isArray(json.content) ? json.content : []
+    // Any non-empty content array counts as having content
+    return content.length > 0
+  } catch {
+    return false
+  }
+}
+


### PR DESCRIPTION
Project folder: /home/bintangputra/osc

Reasoning: This task is necessary to fix a critical runtime error (`SyntaxError: Unexpected token '<' ... is not valid JSON`) that occurs when editing "Features". The Tiptap/Novel editor expects content in Tiptap/ProseMirror JSON format but is receiving raw HTML, causing it to crash. This fix will normalize all rich-text content to JSON, ensuring data consistency and preventing future crashes, while maintaining backward compatibility for legacy HTML content by converting it on the fly.

Feature Slug: tiptap-html-to-json-normalization

Purpose:
- Fix runtime error when editing Features: the editor expects Tiptap/ProseMirror JSON but receives raw HTML.
- Ensure consistent rich-text content format across the app (JSON), with backward-compatible loading of legacy HTML.

Scope:
- Frontend: Update the Features edit page and shared editor component to accept either HTML or JSON input; normalize to JSON before initializing the editor; serialize as JSON on save.
- Backend: Ensure the features.content (or equivalent) is stored and returned as JSON; add casting, validation, and migration guidance.
- Data migration strategy: Non-destructive; convert on read (client) immediately, and plan server-side migration as a follow-up.

Code References (adjust if names differ):
- webapp/resources/js/Pages/Features/Edit.vue (or the page mounting the editor).
- webapp/resources/js/Components/RichTextEditor.vue (Novel/Tiptap wrapper, if exists).
- webapp/resources/js/utils/richtext.ts (new) — normalization helpers.
- webapp/app/Http/Controllers/FeatureController.php — returns edit data, handles updates.
- webapp/app/Models/Feature.php — JSON casting.
- webapp/database/migrations/*_create_features_table.php — content column type.
- webapp/routes/web.php — features edit/update routes.

Constraints:
- Stack: Laravel, Vue 3, Inertia 2.0; dev DB SQLite.
- No external services; use Tiptap APIs only.
- Keep current UX and styles; change only serialization and normalization logic.
- Backward compatibility: Existing HTML must render correctly without breaking DB.

Error Handling:
- Safely detect input type:
    - If string and valid JSON → parse.
    - If string and looks like HTML → convert to Tiptap JSON via generateJSON(...).
    - If empty/invalid → use a minimal empty doc { type: 'doc', content: [{ type: 'paragraph' }] }.
- Never call JSON.parse on HTML strings.
- Log a console warning on fallback conversions; do not throw.

Acceptance Criteria:
- Editing an existing Feature with HTML content loads without error; editor shows the content correctly.
- Creating/updating stores content as JSON in the DB; subsequent loads reuse JSON with no conversions.
- No JSON.parse errors in browser console; no runtime errors from novel-vue/tiptap.
- API accepts and returns JSON content; Inertia props pass arrays/objects (not HTML strings).
- If server returns HTML, client converts it to JSON and initializes editor.
- Validation rules accept array/json; saving with JSON succeeds.

Out of Scope:
- Styling changes, toolbar feature additions, or new editor extensions.
- Full server-side backfill of historical HTML records to JSON (add as follow-up task).

Objective Actions (do exactly this):
1. Add rich-text normalization utils in `webapp/resources/js/utils/richtext.ts`.
2. Update editor wrapper (`webapp/resources/js/Components/RichTextEditor.vue`) to normalize input before mount.
3. Update Features edit page (`webapp/resources/js/Pages/Features/Edit.vue`) to use JSON end-to-end.
4. Backend: ensure JSON casting (`'content' => 'array'`) and validation (`'content' => ['required','array']`) in `webapp/app/Models/Feature.php` and `FeatureController`.
5. DB column check and migration guidance.
6. Guard against regressions.

Sample Code Stubs:
- `resources/js/utils/richtext.ts`: 
    import { generateJSON } from '@tiptap/html'
    export function emptyDoc(){ return { type: 'doc', content: [{ type: 'paragraph' }] } }
    export function isJSONLike(v){ if (v && typeof v === 'object') return true; if (typeof v !== 'string') return false; const s=v.trim(); if (!(s.startsWith('{')||s.startsWith('['))) return false; try{ JSON.parse(s); return true; }catch{return false} }
    export function isHTMLLike(v){ return typeof v==='string' && /<w+[s>]/.test(v) }
    export function toTiptapJSON(input, extensions){ try{ if (input && typeof input==='object') return input; if (isJSONLike(input)) return JSON.parse(input as string); if (isHTMLLike(input)) return generateJSON(input as string, extensions); return emptyDoc(); } catch { return emptyDoc(); } }
- Editor wrapper setup snippet:
    const extensions = [StarterKit.configure({ /* your opts */ })]
    const initial = toTiptapJSON(props.modelValue, extensions)
    const editor = useEditor({ extensions, content: initial, onUpdate: ({editor}) => emit('update:modelValue', editor.getJSON()) })
- Laravel model cast: `protected $casts = ['content' => 'array'];`
- Laravel validation: `request()->validate(['content' => ['required','array']]);`

Verification Steps:
- Seed or edit a Feature whose content is raw `<p>...</p>` HTML.
- Load /features/{id}/edit: No JSON parse error; content visible.
- Type and save: Backend receives JSON array/object; DB column stores JSON.
- Reload: Data comes back as JSON; editor initializes without conversion; no console errors.