### PR TITLE
Fix SOAP Modal (Dialog a11y/centering), Ziggy route mismatch, and WYSIWYG/Timeline rendering (vibe-kanban)

### DIFF
--- a/webapp/resources/js/components/ui/dialog/DialogContent.vue
+++ b/webapp/resources/js/components/ui/dialog/DialogContent.vue
@@ -31,24 +31,32 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <DialogPortal>
-    <DialogOverlay />
-    <DialogContent
-      data-slot="dialog-content"
-      v-bind="forwarded"
-      :class="
-        cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
-          props.class,
-        )"
-    >
-      <slot />
-
-      <DialogClose
-        class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+    <DialogOverlay class="fixed inset-0 z-50 grid place-items-center overflow-y-auto bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+      <DialogContent
+        data-slot="dialog-content"
+        v-bind="forwarded"
+        :class="
+          cn(
+            'relative z-50 grid w-full max-w-[calc(100%-2rem)] my-8 gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg',
+            props.class,
+          )"
+        @pointer-down-outside="(event) => {
+          const originalEvent = event.detail.originalEvent;
+          const target = originalEvent.target as HTMLElement;
+          if (originalEvent.offsetX > target.clientWidth || originalEvent.offsetY > target.clientHeight) {
+            event.preventDefault();
+          }
+        }"
       >
-        <X />
-        <span class="sr-only">Close</span>
-      </DialogClose>
-    </DialogContent>
+        <slot />
+
+        <DialogClose
+          class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        >
+          <X />
+          <span class="sr-only">Close</span>
+        </DialogClose>
+      </DialogContent>
+    </DialogOverlay>
   </DialogPortal>
 </template>

--- a/webapp/resources/js/components/ui/dialog/DialogContent.vue
+++ b/webapp/resources/js/components/ui/dialog/DialogContent.vue
@@ -17,6 +17,11 @@ const emits = defineEmits<DialogContentEmits>()
 
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
+  
+  // Remove aria-describedby if it's undefined/empty to prevent a11y warnings
+  if (!delegated['aria-describedby']) {
+    delete delegated['aria-describedby']
+  }
 
   return delegated
 })
@@ -32,7 +37,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="forwarded"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           props.class,
         )"
     >

--- a/webapp/resources/js/components/ui/dialog/DialogScrollContent.vue
+++ b/webapp/resources/js/components/ui/dialog/DialogScrollContent.vue
@@ -37,7 +37,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       <DialogContent
         :class="
           cn(
-            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
+            'relative z-50 grid w-full max-w-[calc(100%-2rem)] my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg sm:max-w-lg md:w-full',
             props.class,
           )
         "

--- a/webapp/resources/js/components/ui/dialog/DialogScrollContent.vue
+++ b/webapp/resources/js/components/ui/dialog/DialogScrollContent.vue
@@ -17,6 +17,11 @@ const emits = defineEmits<DialogContentEmits>()
 
 const delegatedProps = computed(() => {
   const { class: _, ...delegated } = props
+  
+  // Remove aria-describedby if it's undefined/empty to prevent a11y warnings
+  if (!delegated['aria-describedby']) {
+    delete delegated['aria-describedby']
+  }
 
   return delegated
 })

--- a/webapp/resources/js/components/ui/sheet/SheetContent.vue
+++ b/webapp/resources/js/components/ui/sheet/SheetContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
+import { computed } from 'vue'
 import { cn } from '@/lib/utils'
 import { reactiveOmit } from '@vueuse/core'
 import { X } from 'lucide-vue-next'
@@ -29,7 +30,16 @@ const emits = defineEmits<DialogContentEmits>()
 
 const delegatedProps = reactiveOmit(props, 'class', 'side')
 
-const forwarded = useForwardPropsEmits(delegatedProps, emits)
+// Clean up undefined aria-describedby to prevent a11y warnings
+const cleanedProps = computed(() => {
+  const cleaned = { ...delegatedProps }
+  if (!cleaned['aria-describedby']) {
+    delete cleaned['aria-describedby']
+  }
+  return cleaned
+})
+
+const forwarded = useForwardPropsEmits(cleanedProps, emits)
 </script>
 
 <template>

--- a/webapp/resources/js/pages/Soap/Board.vue
+++ b/webapp/resources/js/pages/Soap/Board.vue
@@ -13,6 +13,7 @@ import InitialAvatar from '@/components/avatar/InitialAvatar.vue';
 import SoapNovelEditorClean from '@/components/SoapNovelEditorClean.vue';
 import { Label } from '@/components/ui/label';
 import { sanitizeHtml, stripHtml } from '@/utils/sanitize';
+import { toHTML } from '@/utils/richtext';
 import axios from 'axios';
 
 const props = defineProps<{
@@ -124,15 +125,35 @@ const loadMoreSoapNotes = async () => {
 };
 
 function simpleText(content: any): string {
-  return stripHtml(JSON.stringify(content || ''));
+  if (!content) return '';
+  try {
+    // Convert TipTap JSON to HTML first, then strip HTML tags
+    const html = toHTML(content);
+    return stripHtml(html);
+  } catch (error) {
+    console.warn('Error converting content to text:', error);
+    return '';
+  }
 }
 
 function preview(content: any): string {
-  const raw = simpleText(content);
-  return raw.substring(0, 120) || 'Empty';
+  const text = simpleText(content);
+  return text.substring(0, 120) || 'Empty';
 }
 
-// Composer modal inside SOAP modal
+function renderHtml(content: any): string {
+  if (!content) return '';
+  try {
+    // Convert TipTap JSON to sanitized HTML
+    const html = toHTML(content);
+    return sanitizeHtml(html);
+  } catch (error) {
+    console.warn('Error rendering content as HTML:', error);
+    return '';
+  }
+}
+
+// SOAP note form (now integrated in main modal)
 const showComposer = ref(false);
 const noteForm = useForm({ subjective: {}, objective: {}, assessment: {}, plan: {} });
 const composerSaving = ref(false);
@@ -145,8 +166,8 @@ const submitNote = async () => {
     await loadSoapData(selectedPatientId.value!);
     noteForm.reset();
   } catch (e) {
-    // Leave modal open for inline errors if any future validation added
-    console.error(e);
+    console.error('Error saving SOAP note:', e);
+    // Keep composer open so user can try again
   } finally {
     composerSaving.value = false;
   }
@@ -362,10 +383,57 @@ const submitComment = async (noteId: number) => {
 
   <!-- SOAP Modal with Timeline -->
   <AppModal v-model="showSoap" :title="soapPatient ? `SOAP - ${soapPatient.name}` : 'SOAP'" width="xl">
-    <div v-if="soapPatient" class="space-y-4">
+    <div v-if="soapPatient" class="space-y-6">
       <div class="flex items-center justify-between">
         <div class="text-sm text-gray-600">{{ soapPatient.bangsal }} / {{ soapPatient.nomor_kamar }}</div>
-        <Button size="sm" @click="showComposer = true">Add SOAP Timeline</Button>
+        <Button size="sm" @click="showComposer = !showComposer">
+          {{ showComposer ? 'Cancel' : 'Add SOAP Timeline' }}
+        </Button>
+      </div>
+
+      <!-- Add SOAP Timeline Form (integrated) -->
+      <div v-if="showComposer" class="border rounded-lg p-4 bg-gray-50">
+        <h3 class="text-lg font-medium mb-4">New SOAP Note</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <Label class="text-sm font-medium">Subjective</Label>
+            <SoapNovelEditorClean 
+              v-model="noteForm.subjective" 
+              placeholder="Subjective findings..."
+              min-height="120px"
+            />
+          </div>
+          <div>
+            <Label class="text-sm font-medium">Objective</Label>
+            <SoapNovelEditorClean 
+              v-model="noteForm.objective" 
+              placeholder="Objective findings..."
+              min-height="120px"
+            />
+          </div>
+          <div>
+            <Label class="text-sm font-medium">Assessment</Label>
+            <SoapNovelEditorClean 
+              v-model="noteForm.assessment" 
+              placeholder="Assessment..."
+              min-height="120px"
+            />
+          </div>
+          <div>
+            <Label class="text-sm font-medium">Plan</Label>
+            <SoapNovelEditorClean 
+              v-model="noteForm.plan" 
+              placeholder="Plan..."
+              min-height="120px"
+            />
+          </div>
+        </div>
+        <div class="flex justify-end gap-2 mt-4">
+          <Button @click="showComposer = false" variant="outline" size="sm">Cancel</Button>
+          <Button @click="submitNote" :disabled="composerSaving" size="sm">
+            {{ composerSaving ? 'Saving...' : 'Save SOAP Note' }}
+          </Button>
+        </div>
       </div>
 
       <div class="space-y-4">
@@ -442,19 +510,19 @@ const submitComment = async (noteId: number) => {
               <div class="mt-3 space-y-3">
                 <div v-if="note.subjective" class="border-l-4 border-blue-500 pl-3">
                   <h4 class="font-medium text-sm text-blue-700">Subjective</h4>
-                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.subjective))"></div>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="renderHtml(note.subjective)"></div>
                 </div>
                 <div v-if="note.objective" class="border-l-4 border-green-500 pl-3">
                   <h4 class="font-medium text-sm text-green-700">Objective</h4>
-                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.objective))"></div>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="renderHtml(note.objective)"></div>
                 </div>
                 <div v-if="note.assessment" class="border-l-4 border-yellow-500 pl-3">
                   <h4 class="font-medium text-sm text-yellow-700">Assessment</h4>
-                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.assessment))"></div>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="renderHtml(note.assessment)"></div>
                 </div>
                 <div v-if="note.plan" class="border-l-4 border-purple-500 pl-3">
                   <h4 class="font-medium text-sm text-purple-700">Plan</h4>
-                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.plan))"></div>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="renderHtml(note.plan)"></div>
                 </div>
               </div>
             </details>
@@ -508,32 +576,6 @@ const submitComment = async (noteId: number) => {
         </Button>
       </div>
     </div>
-  </AppModal>
-
-  <!-- Composer Modal -->
-  <AppModal v-model="showComposer" title="Add SOAP Timeline" width="lg">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <Label>Subjective</Label>
-        <SoapNovelEditorClean v-model="noteForm.subjective" />
-      </div>
-      <div>
-        <Label>Objective</Label>
-        <SoapNovelEditorClean v-model="noteForm.objective" />
-      </div>
-      <div>
-        <Label>Assessment</Label>
-        <SoapNovelEditorClean v-model="noteForm.assessment" />
-      </div>
-      <div>
-        <Label>Plan</Label>
-        <SoapNovelEditorClean v-model="noteForm.plan" />
-      </div>
-    </div>
-    <template #actions>
-      <Button type="button" variant="outline" @click="showComposer = false">Cancel</Button>
-      <Button type="button" :disabled="composerSaving" @click="submitNote">Save</Button>
-    </template>
   </AppModal>
 
 </template>

--- a/webapp/resources/js/pages/Soap/Board.vue
+++ b/webapp/resources/js/pages/Soap/Board.vue
@@ -88,6 +88,10 @@ const soapNotes = ref<any[]>([]);
 const soapNextPageUrl = ref<string | null>(null);
 const soapLoading = ref(false);
 
+// Note editing state
+const editingNoteId = ref<number | null>(null);
+const noteEditForms = ref<{[key: number]: any}>({});
+
 const openSoapModal = async (patientId: number) => {
   selectedPatientId.value = patientId;
   showSoap.value = true;
@@ -145,6 +149,86 @@ const submitNote = async () => {
     console.error(e);
   } finally {
     composerSaving.value = false;
+  }
+};
+
+// Note editing functions
+const startEditingNote = (note: any) => {
+  editingNoteId.value = note.id;
+  noteEditForms.value[note.id] = {
+    subjective: note.subjective || {},
+    objective: note.objective || {},
+    assessment: note.assessment || {},
+    plan: note.plan || {},
+  };
+};
+
+const cancelEditingNote = () => {
+  if (editingNoteId.value) {
+    delete noteEditForms.value[editingNoteId.value];
+  }
+  editingNoteId.value = null;
+};
+
+const saveEditingNote = async () => {
+  if (!editingNoteId.value) return;
+  
+  try {
+    const formData = noteEditForms.value[editingNoteId.value];
+    await axios.put(route('soap.update', editingNoteId.value), formData);
+    
+    // Refresh SOAP data
+    if (selectedPatientId.value) {
+      await loadSoapData(selectedPatientId.value);
+    }
+    
+    // Clear editing state
+    delete noteEditForms.value[editingNoteId.value];
+    editingNoteId.value = null;
+  } catch (error) {
+    console.error('Failed to update note:', error);
+  }
+};
+
+// Comments functionality
+const expandedNotes = ref<Set<number>>(new Set());
+const noteComments = ref<{[key: number]: any[]}>({});
+const commentForms = ref<{[key: number]: string}>({});
+const loadingComments = ref<Set<number>>(new Set());
+
+const toggleNoteComments = async (noteId: number) => {
+  if (expandedNotes.value.has(noteId)) {
+    expandedNotes.value.delete(noteId);
+  } else {
+    expandedNotes.value.add(noteId);
+    if (!noteComments.value[noteId]) {
+      await loadNoteComments(noteId);
+    }
+  }
+};
+
+const loadNoteComments = async (noteId: number) => {
+  loadingComments.value.add(noteId);
+  try {
+    const { data } = await axios.get(route('soap.comments.index', noteId));
+    noteComments.value[noteId] = data.data;
+  } catch (error) {
+    console.error('Failed to load comments:', error);
+  } finally {
+    loadingComments.value.delete(noteId);
+  }
+};
+
+const submitComment = async (noteId: number) => {
+  const body = commentForms.value[noteId];
+  if (!body?.trim()) return;
+  
+  try {
+    await axios.post(route('soap.comments.store', noteId), { body });
+    commentForms.value[noteId] = '';
+    await loadNoteComments(noteId); // Refresh comments
+  } catch (error) {
+    console.error('Failed to submit comment:', error);
   }
 };
 
@@ -284,25 +368,144 @@ const submitNote = async () => {
         <Button size="sm" @click="showComposer = true">Add SOAP Timeline</Button>
       </div>
 
-      <div class="space-y-3">
-        <div v-for="note in soapNotes" :key="note.id" class="border rounded p-3">
-          <div class="flex items-center justify-between">
+      <div class="space-y-4">
+        <div v-for="note in soapNotes" :key="note.id" class="border rounded-lg p-4">
+          <!-- Note Header -->
+          <div class="flex items-center justify-between mb-3">
             <div class="flex items-center gap-2">
               <InitialAvatar :name="note.author?.name" size="sm" />
               <span class="font-medium">{{ note.author?.name }}</span>
               <Badge :class="note.state === 'draft' ? 'bg-yellow-500' : 'bg-green-500'">{{ note.state }}</Badge>
             </div>
-            <span class="text-xs text-gray-500">{{ rel(note.created_at) }}</span>
-          </div>
-          <details class="mt-2">
-            <summary class="cursor-pointer text-sm text-gray-700">{{ preview(note.subjective) }}...</summary>
-            <div class="mt-2 text-sm text-gray-800">
-              <div class="prose prose-sm max-w-none" v-html="sanitizeHtml(simpleText(note.subjective))"></div>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-gray-500">{{ rel(note.created_at) }}</span>
+              <Button 
+                v-if="editingNoteId !== note.id && note.state === 'draft'" 
+                @click="startEditingNote(note)" 
+                size="sm" 
+                variant="outline"
+              >
+                Edit
+              </Button>
             </div>
-          </details>
+          </div>
+
+          <!-- Note Content -->
+          <div v-if="editingNoteId === note.id" class="space-y-4">
+            <!-- Editing Mode -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label class="text-sm font-medium">Subjective</Label>
+                <SoapNovelEditorClean 
+                  v-model="noteEditForms[note.id].subjective" 
+                  :note-id="note.id"
+                  min-height="120px"
+                />
+              </div>
+              <div>
+                <Label class="text-sm font-medium">Objective</Label>
+                <SoapNovelEditorClean 
+                  v-model="noteEditForms[note.id].objective" 
+                  :note-id="note.id"
+                  min-height="120px"
+                />
+              </div>
+              <div>
+                <Label class="text-sm font-medium">Assessment</Label>
+                <SoapNovelEditorClean 
+                  v-model="noteEditForms[note.id].assessment" 
+                  :note-id="note.id"
+                  min-height="120px"
+                />
+              </div>
+              <div>
+                <Label class="text-sm font-medium">Plan</Label>
+                <SoapNovelEditorClean 
+                  v-model="noteEditForms[note.id].plan" 
+                  :note-id="note.id"
+                  min-height="120px"
+                />
+              </div>
+            </div>
+            <div class="flex justify-end gap-2">
+              <Button @click="cancelEditingNote" variant="outline" size="sm">Cancel</Button>
+              <Button @click="saveEditingNote" size="sm">Save Changes</Button>
+            </div>
+          </div>
+          
+          <div v-else>
+            <!-- Display Mode -->
+            <details class="group">
+              <summary class="cursor-pointer text-sm text-gray-700 hover:text-gray-900">
+                {{ preview(note.subjective) }}...
+              </summary>
+              <div class="mt-3 space-y-3">
+                <div v-if="note.subjective" class="border-l-4 border-blue-500 pl-3">
+                  <h4 class="font-medium text-sm text-blue-700">Subjective</h4>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.subjective))"></div>
+                </div>
+                <div v-if="note.objective" class="border-l-4 border-green-500 pl-3">
+                  <h4 class="font-medium text-sm text-green-700">Objective</h4>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.objective))"></div>
+                </div>
+                <div v-if="note.assessment" class="border-l-4 border-yellow-500 pl-3">
+                  <h4 class="font-medium text-sm text-yellow-700">Assessment</h4>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.assessment))"></div>
+                </div>
+                <div v-if="note.plan" class="border-l-4 border-purple-500 pl-3">
+                  <h4 class="font-medium text-sm text-purple-700">Plan</h4>
+                  <div class="prose prose-sm max-w-none mt-1" v-html="sanitizeHtml(simpleText(note.plan))"></div>
+                </div>
+              </div>
+            </details>
+            
+            <!-- Comments Section -->
+            <div class="mt-3 border-t pt-3">
+              <Button 
+                @click="toggleNoteComments(note.id)" 
+                variant="ghost" 
+                size="sm" 
+                class="text-xs text-gray-500 hover:text-gray-700"
+              >
+                {{ expandedNotes.has(note.id) ? 'Hide' : 'Show' }} Comments
+              </Button>
+              
+              <div v-if="expandedNotes.has(note.id)" class="mt-2">
+                <!-- Comments List -->
+                <div v-if="loadingComments.has(note.id)" class="text-xs text-gray-500">Loading comments...</div>
+                <div v-else-if="noteComments[note.id]?.length" class="space-y-2 mb-3">
+                  <div 
+                    v-for="comment in noteComments[note.id]" 
+                    :key="comment.id" 
+                    class="bg-gray-50 rounded p-2 text-sm"
+                  >
+                    <div class="flex items-center justify-between mb-1">
+                      <span class="font-medium text-xs">{{ comment.author?.name }}</span>
+                      <span class="text-xs text-gray-500">{{ rel(comment.created_at) }}</span>
+                    </div>
+                    <div>{{ comment.body }}</div>
+                  </div>
+                </div>
+                
+                <!-- Add Comment Form -->
+                <div class="flex gap-2">
+                  <Input 
+                    v-model="commentForms[note.id]" 
+                    placeholder="Add a comment..." 
+                    size="sm" 
+                    @keyup.enter="submitComment(note.id)"
+                  />
+                  <Button @click="submitComment(note.id)" size="sm">Post</Button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div v-if="soapLoading" class="text-center text-sm">Loading...</div>
-        <Button v-if="soapNextPageUrl" @click="loadMoreSoapNotes" class="w-full" variant="outline" size="sm">Load More</Button>
+        
+        <div v-if="soapLoading" class="text-center text-sm text-gray-500">Loading...</div>
+        <Button v-if="soapNextPageUrl" @click="loadMoreSoapNotes" class="w-full" variant="outline" size="sm">
+          Load More SOAP Notes
+        </Button>
       </div>
     </div>
   </AppModal>


### PR DESCRIPTION
Fix SOAP Modal (Dialog a11y/centering), Ziggy route mismatch, and
WYSIWYG/Timeline rendering

- Purpose: Resolve broken SOAP modal behaviors: accessibility warnings,
mis-centered dialog, missing Tiptap WYSIWYG and past SOAP Timeline; eliminate
Ziggy route errors.
- Errors to fix:
    - Warning: Missing Description or aria-describedby="undefined" for
DialogContent.
    - Vue warn: Unhandled error during native event handler in CardTitle (modal
open path).
    - Ziggy error: route api.soap.patient not in route list.
    - Modal “Add Patient” not centered; SOAP modal missing Tiptap and past SOAP
Timeline.

Scope

- Dialog a11y: Prevent undefined ARIA attributes; provide description hook.
- Dialog centering: Enforce robust viewport-centered positioning.
- Ziggy: Replace nonexistent api.soap.patient usage with valid routes or add a
proper API endpoint.
- SOAP modal content: Ensure Tiptap WYSIWYG and past SOAP Timeline render on
open; comments work.

Constraints

- Keep module isolated to SOAP; do not refactor unrelated features.
- Reuse existing Laravel routes when possible: soap.board, soap.page,
soap.store, soap.update, soap.finalize, soap.destroy, soap.restore, soap.attach,
soap.upload-image, soap.comments.*.
- No heavy new dependencies; use existing reka-ui dialog and Tiptap components.
- Maintain Laravel + Inertia conventions; Ziggy for web routes; plain /api/...
if adding API.

Code References

- Dialog wrappers:
    - webapp/resources/js/components/ui/dialog/DialogContent.vue
    - webapp/resources/js/components/ui/dialog/DialogScrollContent.vue
    - webapp/resources/js/components/ui/sheet/SheetContent.vue
- SOAP pages/components:
    - webapp/resources/js/pages/Soap/Board.vue
    - webapp/resources/js/pages/Soap/Page.vue
    - webapp/resources/js/components/SoapNovelEditor.vue
    - webapp/resources/js/components/SoapNovelEditorClean.vue
- Ziggy setup:
    - webapp/resources/js/app.ts, webapp/resources/js/ssr.ts
- Routes:
    - webapp/routes/web.php (soap.* exists; no api.soap.patient)

Tasks (do exactly this)

1. Dialog a11y (remove undefined ARIA)

- In DialogContent.vue (and similar wrappers), ensure falsy aria-describedby is
not forwarded:
    - Strip aria-describedby if undefined/empty before v-bind="forwarded".
    - Provide an optional <slot name="description"> that renders a hidden node
with a generated id; if present, set aria-describedby to that id.
- Result: No “Missing Description” warning; valid a11y attributes only when
description exists.

2. Dialog centering (robust positioning)

- Keep fixed and translate centering: fixed top-1/2 left-1/2 -translate-x-1/2
-translate-y-1/2 z-50.
- If parent transforms disrupt positioning, wrap content with overlay using
one of:
    - Existing overlay + centered panel, or
    - fixed inset-0 z-50 grid place-items-center container and center panel
via grid.
- Apply to all dialog usages, including any Add Patient modal and SOAP modal.

3. Ziggy route alignment (remove api.soap.patient error)

- Search for route('api.soap.patient') usage in dashboard/board/modal code.
- Replace with:
    - Navigation: route('soap.page', patientId).
    - Data fetch (if needed): add an API endpoint or use Inertia web routes.
    - Option A (web): Use existing `soap.page` and preload needed props via
Inertia.
    - Option B (api): In `webapp/routes/api.php`:
`Route::get('soap/patients/{patient}', [SoapPageController::class,
'showJson'])->name('api.soap.patients.show');`
      - Implement `showJson` to return JSON: patient + notes (newest first),
author, state, created_at; non-admins don’t see soft-deleted.
      - Use axios on `/api/soap/patients/{id}` directly (no Ziggy needed), or
expose route to Ziggy if required.

4. SOAP modal content (editor + timeline)

- Ensure the SOAP modal component (triggered from dashboard/board) renders:
    - Tiptap editor: import and mount SoapNovelEditorClean.vue (or
SoapNovelEditor.vue) only when modal is open. Pass noteId where available to
support soap.upload-image. Use toTiptapJSON with existing content or emptyDoc()
for new drafts.
    - Past SOAP Timeline: on open, fetch notes for the patient ordered
created_at desc. Render relative timestamps (“Xs/m/h/d ago”) consistent with
Soap/Page.vue. Show state badge (draft/finalized) and author name.
    - Comments: lazy-load on expand using route('soap.comments.index', note.id);
posting via route('soap.comments.store', note.id); refresh list after post.
- Ensure initialization on each modal open is idempotent (no double-mount).
Destroy editor on close to prevent leaks.

5. Visual + UX

- Modal title visible; optional description slot; focus trap; Esc/close button
works; close has sr-only label.
- Preserve scroll handling and partial reload patterns consistent with the app.
- For “Add Patient” usage:
    - If it’s a modal elsewhere, apply same centering/a11y; otherwise keep
current link to route('patients.create').

6. Documentation (inline in PR/commit message)

- Note any new API endpoint (name, URL, payload).
- Mention the a11y change (description slot / conditional aria-describedby).
- Note modal centering strategy chosen.

Acceptance Criteria

- No console warning: “Missing Description or aria-describedby="undefined"” for
any dialog usage.
- Add Patient and SOAP modals open perfectly centered on desktop and mobile;
unaffected by layout transforms.
- No Ziggy error: api.soap.patient usage removed or replaced; navigation and/or
JSON fetch works.
- SOAP modal shows:
    - Tiptap WYSIWYG ready to edit on open.
    - Past SOAP Timeline (newest first) with relative time and state badges.
    - Comments load and can be posted.
- Full SOAP page (/soap/patients/{id}) remains fully functional.

Deliverables

- Updated dialogs:
    - webapp/resources/js/components/ui/dialog/DialogContent.vue
    - (If needed) DialogScrollContent.vue, ui/sheet/SheetContent.vue
- Updated modal trigger/callers:
    - The component(s) opening SOAP modal from dashboard/board.
- Optional new API route and controller method:
    - webapp/routes/api.php
    - SoapPageController@showJson (if API chosen)
- Any minimal adjustments in Soap/Page.vue or Soap/Board.vue if shared helpers
are extracted or reused.

Route Usage Guidance

- Navigate to SOAP page: router.get(route('soap.page', patientId)).
- Create/update notes (already present): soap.store, soap.update, soap.finalize.
- Attachments/image uploads: soap.attach, soap.upload-image.
- Comments: soap.comments.index and soap.comments.store.
- If adding API, use axios with /api/soap/patients/{id}; avoid Ziggy unless
configured to include API routes.