### PR TITLE
Project Prompt — Continue OSCE Rationalization Flow (Laravel + Inertia + Vue) (vibe-kanban)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,89 @@
+# OSCE Rationalization Flow — Implementation Report
+
+This report summarizes what was implemented to enable the OSCE flow: Rasionalisasi (post‑session reflection) → View Results → Scoring, what should be working now, and what is not implemented yet.
+
+## What’s Implemented (Should Be Working)
+- Rationalization as a post‑session step
+  - New page: `GET /osce/rationalization/{session}` shows a reflection summary (reasoning score, total test cost, evaluation feedback) and a button to complete the rationalization.
+  - New action: `POST /api/osce/sessions/{session}/rationalization/complete` sets `rationalization_completed_at` and redirects to results.
+  - Database: new column `osce_sessions.rationalization_completed_at` (nullable `timestamp`).
+
+- Single source of truth for gating
+  - Results (page and JSON) are viewable only when `rationalization_completed_at` is set.
+  - Access to results before rationalization completion redirects to the rationalization page with a warning message.
+  - Source: `OsceSession::getIsRationalizationCompleteAttribute()`.
+
+- Dashboard CTAs reflect the flow
+  - In progress → “Continue” (goes to `/osce/chat/{session}`).
+  - Completed but not rationalized → “Rasionalisasi” (goes to `/osce/rationalization/{session}`) and “View Results” disabled with helper text.
+  - Completed and rationalized → “View Results” enabled.
+  - These booleans are computed server‑side and passed to Inertia props: `canRationalize`, `canViewResults`, `canProceedToScoring`.
+
+- Results page: Clinical Reasoning section
+  - Dedicated card rendering the AI clinical‑reasoning area (or fallback) and showing rationalization contributions (`clinical_reasoning_score`, `total_test_cost`, `evaluation_feedback`).
+  - Quick jump button “Go to Clinical Reasoning”.
+
+- AI assessment fallback (no Gemini key / API error)
+  - If Gemini is not configured or returns an error, the backend computes rubric‑based scores (using `config/osce_scoring.php`) and persists a structured `assessor_output` so the Results page always has content.
+  - You can force re‑assessment from the Results page (Reassess button) which re‑runs assessment and reloads the page.
+
+- Routes (visible via `php artisan route:list`)
+  - `GET  /osce` (dashboard)
+  - `GET  /osce/chat/{session}` (live session)
+  - `GET  /osce/rationalization/{session}` (post‑session reflection)
+  - `POST /api/osce/sessions/{session}/rationalization/complete`
+  - `GET  /osce/results/{session}` (guarded by rationalization)
+  - `GET  /osce/scoring/{session}` (alias → same view/guard)
+  - `GET  /api/osce/sessions/{session}/results` (JSON; guarded)
+
+## Files Changed / Added
+- Backend
+  - `app/Models/OsceSession.php`: added `rationalization_completed_at` cast and `is_rationalization_complete` accessor.
+  - `database/migrations/2025_08_23_000007_add_rationalization_fields_to_osce_sessions_table.php`: adds the column.
+  - `app/Http/Controllers/OsceRationalizationController.php`: new controller for rationalization show/complete.
+  - `app/Http/Controllers/OsceAssessmentController.php`: gating updated to use `is_rationalization_complete` and redirect to rationalization page when not complete; includes rationalization metrics in props.
+  - `app/Http/Controllers/OsceController.php`: adds server booleans (`canRationalize`, `canViewResults`, `canProceedToScoring`).
+  - `app/Services/AiAssessorService.php`: fallback scoring when Gemini unavailable or errors; splits Clinical Reasoning and Diagnosis in the detailed areas prompt.
+  - `routes/web.php`: adds rationalization routes and scoring alias.
+  - Tests: `tests/Feature/OsceResultsGatingTest.php` updated to reflect the new gating and rationalization completion flag.
+
+- Frontend (Vue/Inertia)
+  - `resources/js/pages/Osce.vue`: CTA logic for Continue / Rasionalisasi / View Results, helper text when results are disabled.
+  - `resources/js/pages/OsceRationalization.vue`: new page for post‑session rationalization with “Selesaikan Rasionalisasi” button.
+  - `resources/js/pages/OsceResult.vue`: dedicated “Clinical Reasoning” section, quick jump button, and renders rationalization metrics from server props.
+
+## Required Post‑Update Steps
+- Clear route cache (so new routes are picked up):
+  - `cd webapp && php artisan route:clear`
+- Run migrations (adds `rationalization_completed_at`):
+  - `cd webapp && php artisan migrate`
+- Run dev stack:
+  - `cd webapp && composer dev` (or `php artisan serve` + `npm run dev`)
+
+## Expected User Flow
+1) Start and complete an OSCE session.
+2) On `/osce` (dashboard):
+   - If the session is in progress → “Continue”.
+   - If the session is completed but not rationalized → “Rasionalisasi” (click to open the rationalization page).
+3) On the rationalization page, click “Selesaikan Rasionalisasi”.
+4) Results become available; “View Results” opens the assessment page with the Clinical Reasoning section.
+5) Optional: “Reassess” on results page to force reassessment (fallback or AI depending on env).
+
+## Works With / Without Gemini
+- Without Gemini: Fallback rubric‑based scoring populates scores and narrative; Results page renders fully.
+- With Gemini: Set `GEMINI_API_KEY` and `GEMINI_MODEL` in `webapp/.env`; background job or local mode will produce AI analysis.
+
+## Not Implemented Yet / Known Limitations
+- Read‑only chat history view after completion (currently chat route redirects once locked). If desired, we can add a read‑only transcript view.
+- Rich rationalization form (current page presents summary + “complete” action; no additional fields are collected).
+- End‑to‑end UI tests (Pest covers backend gating; no Cypress/Playwright tests in this repo).
+- Comprehensive admin tooling (e.g., rationalization resets or reporting) not included.
+- If you had existing assessed sessions with null scores, they will stay until you click “Reassess” (or call the assess API with `{ force: true }`).
+
+## Quick Verification Checklist
+- Dashboard shows correct CTAs per session state.
+- `/osce/rationalization/{id}` loads for completed sessions; completing it enables results.
+- `/osce/results/{id}` loads only after rationalization completion.
+- Results page shows Clinical Reasoning section and rationalization metrics.
+- Assessment works without Gemini (fallback rubric scores present). With Gemini configured, AI narrative appears.
+


### PR DESCRIPTION
Project Prompt — Continue OSCE Rationalization Flow (Laravel + Inertia + Vue)
Context (What Exists Now)

App stack: Laravel (with Inertia) + Vue frontend.

Controller of interest: OsceController::showChat() — ✅ return type fixed to Response|RedirectResponse (redirects for expired/completed sessions; returns Inertia for active).

“OSCE Rationalization system” status: IMPLEMENTED & passes lint. Includes:

✅ DB schema with 4 new tables (rationalization-related).

✅ Gemini API integration that returns medical citations.

✅ Full rationalization workflow (collect, evaluate).

✅ Background job processing for evaluations (queue works).

✅ Vue components with progress tracking UI.

✅ Gating logic that blocks access to OSCE results until rationalization is completed.

✅ Final return type error resolved.

Current problem: “View Results” cannot be clicked (gated). Desired user flow:

Rasionalisasi → 2) View Results → 3) Scoring.

Goal

Fix the flow so users can proceed Rasionalisasi → View Results → Scoring while preserving the requirement that results are only visible after rationalization is completed for that session.

Ensure both backend gating and frontend button/route state are consistent.

Constraints & Notes

Keep existing blocking requirement: results should not be viewable before rationalization completion.

Do not regress existing background jobs / Gemini integration / citations.

Keep type-safety and lint passing.

Prefer minimal, focused changes with tests.

Your Tasks (Do These Exactly, In Order)

Locate the gating logic

Search for middleware/policies/guards that control access to results:

Possible filenames/places:

app/Http/Middleware/*Rationalization* or EnsureRationalization*

app/Policies/*Results*Policy.php

Checks inside ResultsController@show (or similar) and routes/web.php

Any helper like Session::requiresRationalization() or scope on a Rationalization model

Identify which flag/field marks rationalization as complete for a given OSCE session (e.g., rationalizations.status = 'complete', completed_at, or a computed relation).

Deliverable: Brief note in code comments where gating is enforced and which field toggles completion.

Make the gating condition precise

Ensure the condition is: Allow “View Results” only when rationalization for the SAME session is complete.

If gating currently fires too early (e.g., blocks even after completion), fix the predicate:

Prefer a single source of truth: something like

$isComplete = $session->rationalization && $session->rationalization->is_complete; 


Avoid mixed checks (timestamps + status) unless both are required. If both exist, standardize to one and deprecate the other.

Deliverable: Updated middleware/policy/controller check with a clear, unit-tested predicate.

Wire the flow routes clearly

Confirm these routes exist and point to the correct controllers:

Rationalization page (e.g., rationalizations.show for a session)

View Results page (e.g., results.show for a session)

Scoring page (e.g., scoring.show for a session)

In routes/web.php, make sure:

Results route is protected by the corrected gating (middleware or controller guard).

Scoring route requires results viewable (or at minimum the same rationalization completion condition, depending on product rules).

If routes are named inconsistently, normalize names to osce.sessions.rationalization.show, osce.sessions.results.show, osce.sessions.scoring.show.

Deliverable: Route definitions + comments explaining required guards.

Fix the frontend CTA states

In the Vue component(s) that render the “View Results” and “Scoring” buttons:

Bind disabled and to/href to reactive canViewResults and canProceedToScoring computed values.

Source these booleans from the server-provided page props (Inertia) so UI matches backend truth.

Show a concise tooltip or helper text when disabled (e.g., “Selesaikan rasionalisasi terlebih dahulu.”)

Ensure the “View Results” button becomes clickable immediately after rationalization reaches complete state (without full page reload if possible).

Deliverable: Updated Vue with computed guards and visible UX hints.

Ensure the completion transition fires

Verify where rationalization is marked complete:

On final step submission of rationalization UI, or

From a job/webhook after evaluation

Ensure the code sets the completion field and triggers an Inertia redirect/refresh so the next screen shows enabled “View Results”.

If completion is async (job), add a polling or event to refresh the state until complete.

Deliverable: Reliable completion state update + UI state refresh.

Add tests

Feature tests (PHPUnit/Pest):

Given a session without complete rationalization → GET /results 403/redirect.

Given a session with complete rationalization → GET /results 200.

Scoring route follows the same logic as required by the flow.

Vue tests (if applicable) or at least smoke tests:

Buttons disabled/enabled based on canViewResults, canProceedToScoring.

Deliverable: Tests passing.

Acceptance criteria

As a user:

I finish Rasionalisasi for my session.

The View Results button becomes clickable and navigates to results.

From results, I can proceed to Scoring.

If I have not finished rationalization, View Results is disabled and/or the route redirects with a clear message.

Pseudocode / Implementation Hints (Keep It Minimal & Precise)

Controller guard (example):

public function show(Session $session)
{
    abort_unless($session->rationalization?->is_complete, 403, 'Complete rationalization first.');
    return Inertia::render('Results/Show', [
        'sessionId' => $session->id,
        // … other props
        'canProceedToScoring' => true,
    ]);
}


Middleware (if used instead of controller):

public function handle($request, Closure $next)
{
    $session = $request->route('session');
    if (!($session->rationalization && $session->rationalization->is_complete)) {
        return redirect()->route('osce.sessions.rationalization.show', $session)
            ->with('warning', 'Selesaikan rasionalisasi terlebih dahulu.');
    }
    return $next($request);
}


Inertia page props (server-side) to drive UI:

return Inertia::render('Session/Overview', [
    'session' => $session,
    'canViewResults' => (bool) ($session->rationalization?->is_complete),
    'canProceedToScoring' => (bool) ($session->results?->is_viewable), // or same condition
]);


Vue button (example):

<Button :disabled="!$page.props.canViewResults"
        :to="route('osce.sessions.results.show', sessionId)">
  View Results
</Button>
<p v-if="!$page.props.canViewResults" class="text-sm opacity-70">
  Selesaikan rasionalisasi terlebih dahulu.
</p>


Feature tests (outline):

it('blocks results before rationalization', function () {
    $session = Session::factory()->create();
    $this->get(route('osce.sessions.results.show', $session))->assertRedirect();
});

it('allows results after rationalization complete', function () {
    $session = Session::factory()->has(Rationalization::factory()->state(['is_complete' => true]))->create();
    $this->get(route('osce.sessions.results.show', $session))->assertOk();
});

Deliverables Checklist

 Clear identification of gating logic and completion flag

 Corrected backend guard (middleware or controller) with single source of truth

 Routes aligned to flow: Rasionalisasi → View Results → Scoring

 Vue buttons reflect server truth; proper disabled UX

 Completion transition reliably flips state and refreshes UI

 Tests covering blocked/allowed access and button states

 All linters pass; no new type errors

If You Need To Inspect Code, Start Here

routes/web.php

app/Http/Controllers/OsceController.php (confirm showChat())

app/Http/Controllers/ResultsController.php (or equivalent)

app/Http/Controllers/ScoringController.php (or equivalent)

app/Http/Middleware/*Rationalization* (if present)

app/Policies/*Results*Policy.php (if present)

app/Models/Session.php, app/Models/Rationalization.php

Vue pages/components for Session overview & CTA buttons