### PR TITLE
AI JSON Parsing Fix (vibe-kanban)

### DIFF
--- a/webapp/app/Http/Controllers/OsceAssessmentController.php
+++ b/webapp/app/Http/Controllers/OsceAssessmentController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\AiAssessorOrchestrator;
 use App\Jobs\AssessOsceSessionJob;
+use App\Models\AiAssessmentRun;
 use App\Models\OsceSession;
 use App\Services\AiAssessorService;
 use Illuminate\Http\Request;
@@ -53,21 +55,85 @@ class OsceAssessmentController extends Controller
             ]);
         }
 
-        // For development, run synchronously; for production, use queue
-        if (app()->environment('local')) {
-            $assessorService = app(AiAssessorService::class);
-            $assessorService->assess($session, $force);
-            $session->refresh();
-        } else {
-            AssessOsceSessionJob::dispatch($session->id, $force);
+        // Check if there's already a running assessment
+        $existingRun = AiAssessmentRun::where('osce_session_id', $session->id)
+            ->where('status', 'in_progress')
+            ->first();
+
+        if ($existingRun && !$force) {
+            return response()->json([
+                'message' => 'Assessment already in progress',
+                'run_id' => $existingRun->id,
+                'status' => 'in_progress',
+                'progress' => $existingRun->progress_percentage,
+            ]);
         }
 
+        // Dispatch the new orchestrator job
+        AiAssessorOrchestrator::dispatch($session->id, $force);
+        
+        // Get the latest assessment run
+        $assessmentRun = AiAssessmentRun::where('osce_session_id', $session->id)
+            ->latest()
+            ->first();
+
         return response()->json([
-            'message' => 'Assessment '.(app()->environment('local') ? 'completed' : 'queued'),
+            'message' => 'Assessment started',
             'session_id' => $session->id,
-            'score' => $session->score,
-            'max_score' => $session->max_score,
-            'assessed_at' => $session->assessed_at?->toISOString(),
+            'run_id' => $assessmentRun->id ?? null,
+            'status' => 'in_progress',
+        ]);
+    }
+
+    /**
+     * Get assessment status/progress for polling
+     */
+    public function status(OsceSession $session)
+    {
+        // Authorization: only session owner
+        if ($session->user_id !== Auth::id()) {
+            abort(403, 'Unauthorized to view assessment status');
+        }
+
+        $assessmentRun = AiAssessmentRun::where('osce_session_id', $session->id)
+            ->latest()
+            ->with('areaResults')
+            ->first();
+
+        if (!$assessmentRun) {
+            return response()->json([
+                'status' => 'not_started',
+                'message' => 'No assessment run found',
+            ]);
+        }
+
+        $areaResults = $assessmentRun->areaResults->map(function ($result) {
+            return [
+                'area' => $result->area_display_name,
+                'key' => $result->clinical_area,
+                'status' => $result->status,
+                'badge_color' => $result->badge_color,
+                'badge_text' => $result->badge_text,
+                'score' => $result->score,
+                'max_score' => $result->max_score,
+                'was_repaired' => $result->was_repaired,
+                'attempts' => $result->attempts,
+            ];
+        });
+
+        return response()->json([
+            'run_id' => $assessmentRun->id,
+            'status' => $assessmentRun->status,
+            'progress' => $assessmentRun->progress_percentage,
+            'total_score' => $assessmentRun->total_score,
+            'max_possible_score' => $assessmentRun->max_possible_score,
+            'has_fallbacks' => $assessmentRun->has_fallbacks,
+            'completed_areas' => $assessmentRun->completed_areas,
+            'total_areas' => $assessmentRun->total_areas,
+            'area_results' => $areaResults,
+            'started_at' => $assessmentRun->started_at?->toISOString(),
+            'completed_at' => $assessmentRun->completed_at?->toISOString(),
+            'error_message' => $assessmentRun->error_message,
         ]);
     }
 
@@ -90,13 +156,38 @@ class OsceAssessmentController extends Controller
             ], 403);
         }
 
-        if (!$session->assessed_at) {
+        // Check if there's a completed assessment run
+        $assessmentRun = AiAssessmentRun::where('osce_session_id', $session->id)
+            ->where('status', 'completed')
+            ->latest()
+            ->first();
 
+        if (!$assessmentRun && !$session->assessed_at) {
             return response()->json([
                 'error' => 'Session has not been assessed yet',
             ], 404);
         }
 
+        // If we have a new assessment run, use that data
+        if ($assessmentRun) {
+            return response()->json([
+                'session_id' => $session->id,
+                'run_id' => $assessmentRun->id,
+                'score' => $assessmentRun->total_score,
+                'max_score' => $assessmentRun->max_possible_score,
+                'assessed_at' => $assessmentRun->completed_at->toISOString(),
+                'assessor_model' => config('services.gemini.model', 'gemini-2.5-flash'),
+                'assessment_type' => 'detailed_clinical_areas_assessment',
+                'assessor_output' => $assessmentRun->final_result,
+                'case_title' => $session->osceCase->title ?? 'Unknown Case',
+                'user_name' => $session->user->name ?? 'Unknown User',
+                'completed_at' => $session->completed_at?->toISOString(),
+                'has_fallbacks' => $assessmentRun->has_fallbacks,
+                'telemetry' => $assessmentRun->telemetry,
+            ]);
+        }
+
+        // Fallback to legacy assessment data
         return response()->json([
             'session_id' => $session->id,
             'score' => $session->score,
@@ -132,8 +223,15 @@ class OsceAssessmentController extends Controller
         // Load necessary relationships
         $session->load(['osceCase', 'user']);
 
-        // Check if assessed
-        if (! $session->assessed_at) {
+        // Check for new assessment run first
+        $assessmentRun = AiAssessmentRun::where('osce_session_id', $session->id)
+            ->where('status', 'completed')
+            ->latest()
+            ->with('areaResults')
+            ->first();
+
+        // Check if assessed (either new or legacy)
+        if (!$assessmentRun && !$session->assessed_at) {
             return Inertia::render('OsceResult', [
                 'session' => [
                     'id' => $session->id,
@@ -175,15 +273,52 @@ class OsceAssessmentController extends Controller
         }
 
         // Prepare assessment data for frontend
-        $assessmentData = [
-            'score' => $session->score,
-            'max_score' => $session->max_score,
-            'percentage' => $session->max_score > 0 ? round(($session->score / $session->max_score) * 100, 1) : 0,
-            'assessed_at' => $session->assessed_at->toISOString(),
-            'assessor_model' => $session->assessor_model,
-            'assessment_type' => $session->assessor_output['assessment_type'] ?? 'session_assessment',
-            'output' => $session->assessor_output,
-        ];
+        if ($assessmentRun) {
+            // Use new assessment run data
+            $areaResults = $assessmentRun->areaResults->map(function ($result) {
+                return [
+                    'area' => $result->area_display_name,
+                    'key' => $result->clinical_area,
+                    'status' => $result->status,
+                    'badge_color' => $result->badge_color,
+                    'badge_text' => $result->badge_text,
+                    'score' => $result->score,
+                    'max_score' => $result->max_score,
+                    'justification' => $result->justification,
+                    'was_repaired' => $result->was_repaired,
+                    'attempts' => $result->attempts,
+                ];
+            });
+
+            $assessmentData = [
+                'run_id' => $assessmentRun->id,
+                'score' => $assessmentRun->total_score,
+                'max_score' => $assessmentRun->max_possible_score,
+                'percentage' => $assessmentRun->max_possible_score > 0 ? 
+                    round(($assessmentRun->total_score / $assessmentRun->max_possible_score) * 100, 1) : 0,
+                'assessed_at' => $assessmentRun->completed_at->toISOString(),
+                'assessor_model' => config('services.gemini.model', 'gemini-2.5-flash'),
+                'assessment_type' => 'detailed_clinical_areas_assessment',
+                'output' => $assessmentRun->final_result,
+                'has_fallbacks' => $assessmentRun->has_fallbacks,
+                'area_results' => $areaResults,
+                'telemetry' => $assessmentRun->telemetry,
+                'processing_time' => $assessmentRun->completed_at->diffInSeconds($assessmentRun->started_at),
+            ];
+        } else {
+            // Use legacy assessment data
+            $assessmentData = [
+                'score' => $session->score,
+                'max_score' => $session->max_score,
+                'percentage' => $session->max_score > 0 ? round(($session->score / $session->max_score) * 100, 1) : 0,
+                'assessed_at' => $session->assessed_at->toISOString(),
+                'assessor_model' => $session->assessor_model,
+                'assessment_type' => $session->assessor_output['assessment_type'] ?? 'session_assessment',
+                'output' => $session->assessor_output,
+                'has_fallbacks' => false,
+                'is_legacy' => true,
+            ];
+        }
 
         return Inertia::render('OsceResult', [
             'session' => [

--- a/webapp/app/Jobs/AiAssessorOrchestrator.php
+++ b/webapp/app/Jobs/AiAssessorOrchestrator.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AiAssessmentAreaResult;
+use App\Models\AiAssessmentRun;
+use App\Models\OsceSession;
+use App\Services\AreaAssessor;
+use App\Services\ResultReducer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Exception;
+
+class AiAssessorOrchestrator implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $timeout = 600; // 10 minutes timeout
+    public $tries = 1; // Only try once
+
+    public function __construct(
+        public int $sessionId,
+        public bool $force = false
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $session = OsceSession::findOrFail($this->sessionId);
+        
+        Log::info('AiAssessorOrchestrator started', [
+            'session_id' => $this->sessionId,
+            'force' => $this->force
+        ]);
+
+        try {
+            // Create assessment run
+            $assessmentRun = AiAssessmentRun::create([
+                'osce_session_id' => $this->sessionId,
+                'status' => 'in_progress',
+                'started_at' => now(),
+                'max_possible_score' => 85, // Sum of all clinical areas
+            ]);
+
+            // Initialize area results
+            AiAssessmentAreaResult::initializeAreasForRun($assessmentRun->id);
+
+            Log::info('Assessment run created', [
+                'run_id' => $assessmentRun->id,
+                'session_id' => $this->sessionId
+            ]);
+
+            // Process each clinical area sequentially
+            $areaAssessor = app(AreaAssessor::class);
+            $areas = AiAssessmentAreaResult::CLINICAL_AREAS;
+
+            foreach ($areas as $area => $config) {
+                try {
+                    Log::info('Processing clinical area', [
+                        'run_id' => $assessmentRun->id,
+                        'area' => $area
+                    ]);
+
+                    $areaResult = $assessmentRun->areaResults()
+                        ->where('clinical_area', $area)
+                        ->firstOrFail();
+
+                    $areaResult->update(['status' => 'in_progress']);
+
+                    // Process the area
+                    $result = $areaAssessor->assessArea($session, $area, $areaResult);
+                    
+                    Log::info('Area processing completed', [
+                        'run_id' => $assessmentRun->id,
+                        'area' => $area,
+                        'status' => $result['status'],
+                        'score' => $result['score'] ?? null
+                    ]);
+
+                } catch (Exception $e) {
+                    Log::error('Area processing failed', [
+                        'run_id' => $assessmentRun->id,
+                        'area' => $area,
+                        'error' => $e->getMessage()
+                    ]);
+
+                    $assessmentRun->areaResults()
+                        ->where('clinical_area', $area)
+                        ->update([
+                            'status' => 'failed',
+                            'error_message' => $e->getMessage(),
+                        ]);
+                }
+            }
+
+            // Aggregate results using ResultReducer
+            $resultReducer = app(ResultReducer::class);
+            $finalResult = $resultReducer->aggregateResults($assessmentRun);
+
+            // Update assessment run with final results
+            $assessmentRun->update([
+                'status' => 'completed',
+                'completed_at' => now(),
+                'final_result' => $finalResult,
+                'total_score' => $finalResult['total_score'] ?? 0,
+                'telemetry' => $this->generateTelemetry($assessmentRun),
+            ]);
+
+            Log::info('AiAssessorOrchestrator completed', [
+                'run_id' => $assessmentRun->id,
+                'session_id' => $this->sessionId,
+                'total_score' => $finalResult['total_score'] ?? 0,
+                'has_fallbacks' => $assessmentRun->has_fallbacks
+            ]);
+
+        } catch (Exception $e) {
+            Log::error('AiAssessorOrchestrator failed', [
+                'session_id' => $this->sessionId,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            // Update assessment run as failed if it exists
+            if (isset($assessmentRun)) {
+                $assessmentRun->update([
+                    'status' => 'failed',
+                    'error_message' => $e->getMessage(),
+                    'completed_at' => now(),
+                ]);
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Generate telemetry data for the assessment run
+     */
+    private function generateTelemetry(AiAssessmentRun $assessmentRun): array
+    {
+        $areaResults = $assessmentRun->areaResults;
+        
+        $telemetry = [
+            'total_areas' => $areaResults->count(),
+            'completed_areas' => $areaResults->where('status', 'completed')->count(),
+            'fallback_areas' => $areaResults->where('status', 'fallback')->count(),
+            'failed_areas' => $areaResults->where('status', 'failed')->count(),
+            'areas_with_repairs' => $areaResults->where('was_repaired', true)->count(),
+            'total_attempts' => $areaResults->sum('attempts'),
+            'average_response_length' => $areaResults->where('response_length', '>', 0)->avg('response_length'),
+            'processing_time_seconds' => $assessmentRun->completed_at?->diffInSeconds($assessmentRun->started_at),
+            'area_breakdown' => [],
+        ];
+
+        foreach ($areaResults as $result) {
+            $telemetry['area_breakdown'][$result->clinical_area] = [
+                'status' => $result->status,
+                'attempts' => $result->attempts,
+                'was_repaired' => $result->was_repaired,
+                'response_length' => $result->response_length,
+                'score' => $result->score,
+                'max_score' => $result->max_score,
+            ];
+        }
+
+        return $telemetry;
+    }
+
+    /**
+     * Handle job failure
+     */
+    public function failed(Exception $exception): void
+    {
+        Log::error('AiAssessorOrchestrator job failed', [
+            'session_id' => $this->sessionId,
+            'exception' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString()
+        ]);
+    }
+}

--- a/webapp/app/Models/AiAssessmentAreaResult.php
+++ b/webapp/app/Models/AiAssessmentAreaResult.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AiAssessmentAreaResult extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ai_assessment_run_id',
+        'clinical_area',
+        'status',
+        'score',
+        'max_score',
+        'justification',
+        'raw_response',
+        'response_length',
+        'attempts',
+        'was_repaired',
+        'error_message',
+        'telemetry',
+    ];
+
+    protected $casts = [
+        'raw_response' => 'array',
+        'telemetry' => 'array',
+        'was_repaired' => 'boolean',
+    ];
+
+    public const CLINICAL_AREAS = [
+        'history' => ['name' => 'History-Taking', 'max_score' => 20],
+        'exam' => ['name' => 'Physical Examination', 'max_score' => 15],
+        'investigations' => ['name' => 'Investigations', 'max_score' => 20],
+        'differential_diagnosis' => ['name' => 'Differential Diagnosis', 'max_score' => 15],
+        'management' => ['name' => 'Management', 'max_score' => 15],
+    ];
+
+    public function assessmentRun(): BelongsTo
+    {
+        return $this->belongsTo(AiAssessmentRun::class, 'ai_assessment_run_id');
+    }
+
+    public function getIsCompletedAttribute(): bool
+    {
+        return in_array($this->status, ['completed', 'fallback']);
+    }
+
+    public function getIsFailedAttribute(): bool
+    {
+        return $this->status === 'failed';
+    }
+
+    public function getIsFallbackAttribute(): bool
+    {
+        return $this->status === 'fallback';
+    }
+
+    public function getAreaDisplayNameAttribute(): string
+    {
+        return self::CLINICAL_AREAS[$this->clinical_area]['name'] ?? $this->clinical_area;
+    }
+
+    public function getBadgeColorAttribute(): string
+    {
+        return match ($this->status) {
+            'completed' => $this->was_repaired ? 'amber' : 'green',
+            'fallback' => 'gray',
+            'failed' => 'red',
+            'in_progress' => 'blue',
+            default => 'gray'
+        };
+    }
+
+    public function getBadgeTextAttribute(): string
+    {
+        return match ($this->status) {
+            'completed' => $this->was_repaired ? 'AI (Repaired)' : 'AI',
+            'fallback' => 'Rubric',
+            'failed' => 'Failed',
+            'in_progress' => 'Processing',
+            default => 'Pending'
+        };
+    }
+
+    public function getMaxScoreForArea(string $area): int
+    {
+        return self::CLINICAL_AREAS[$area]['max_score'] ?? 10;
+    }
+
+    public static function initializeAreasForRun(int $assessmentRunId): void
+    {
+        foreach (self::CLINICAL_AREAS as $area => $config) {
+            self::create([
+                'ai_assessment_run_id' => $assessmentRunId,
+                'clinical_area' => $area,
+                'max_score' => $config['max_score'],
+                'status' => 'pending',
+            ]);
+        }
+    }
+}

--- a/webapp/app/Models/AiAssessmentRun.php
+++ b/webapp/app/Models/AiAssessmentRun.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AiAssessmentRun extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'osce_session_id',
+        'status',
+        'final_result',
+        'total_score',
+        'max_possible_score',
+        'error_message',
+        'telemetry',
+        'started_at',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'final_result' => 'array',
+        'telemetry' => 'array',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+    ];
+
+    public function osceSession(): BelongsTo
+    {
+        return $this->belongsTo(OsceSession::class);
+    }
+
+    public function areaResults(): HasMany
+    {
+        return $this->hasMany(AiAssessmentAreaResult::class);
+    }
+
+    public function getIsCompletedAttribute(): bool
+    {
+        return $this->status === 'completed';
+    }
+
+    public function getIsFailedAttribute(): bool
+    {
+        return $this->status === 'failed';
+    }
+
+    public function getProgressPercentageAttribute(): int
+    {
+        $totalAreas = 5; // history, exam, investigations, differential_diagnosis, management
+        $completedAreas = $this->areaResults()->whereIn('status', ['completed', 'fallback'])->count();
+        
+        return $totalAreas > 0 ? (int) (($completedAreas / $totalAreas) * 100) : 0;
+    }
+
+    public function getHasFallbacksAttribute(): bool
+    {
+        return $this->areaResults()->where('status', 'fallback')->exists();
+    }
+
+    public function getCompletedAreasAttribute(): int
+    {
+        return $this->areaResults()->whereIn('status', ['completed', 'fallback'])->count();
+    }
+
+    public function getTotalAreasAttribute(): int
+    {
+        return 5; // Fixed number of clinical areas
+    }
+}

--- a/webapp/app/Services/AiAssessorService.php
+++ b/webapp/app/Services/AiAssessorService.php
@@ -391,7 +391,7 @@ class AiAssessorService
         return $scores;
     }
 
-    private function computeCriterionScore(array $criterion, OsceSession $session, $case, array $config): int
+    public function computeCriterionScore(array $criterion, OsceSession $session, $case, array $config): int
     {
         $key = $criterion['key'];
         $max = $criterion['max'];

--- a/webapp/app/Services/AreaAssessor.php
+++ b/webapp/app/Services/AreaAssessor.php
@@ -1,0 +1,607 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AiAssessmentAreaResult;
+use App\Models\OsceSession;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Exception;
+
+class AreaAssessor
+{
+    private ?string $apiKey;
+    private string $baseUrl = 'https://generativelanguage.googleapis.com/v1beta/models';
+    private string $model;
+    private AiAssessorService $aiAssessorService;
+
+    public function __construct(AiAssessorService $aiAssessorService)
+    {
+        $this->apiKey = config('services.gemini.api_key');
+        $this->model = config('services.gemini.model', 'gemini-2.5-flash');
+        $this->aiAssessorService = $aiAssessorService;
+    }
+
+    /**
+     * Assess a specific clinical area for a session
+     */
+    public function assessArea(OsceSession $session, string $area, AiAssessmentAreaResult $areaResult): array
+    {
+        Log::info('AreaAssessor starting', [
+            'session_id' => $session->id,
+            'area' => $area,
+            'area_result_id' => $areaResult->id
+        ]);
+
+        // Load session with relationships for artifact building
+        $session->load([
+            'osceCase',
+            'chatMessages',
+            'orderedTests.medicalTest',
+            'examinations',
+        ]);
+
+        // Build artifact for this specific area
+        $artifact = $this->aiAssessorService->buildArtifact($session);
+        
+        $maxRetries = 2;
+        $attempt = 0;
+
+        while ($attempt < $maxRetries) {
+            $attempt++;
+            $areaResult->update(['attempts' => $attempt]);
+
+            try {
+                Log::info('AreaAssessor attempt', [
+                    'session_id' => $session->id,
+                    'area' => $area,
+                    'attempt' => $attempt
+                ]);
+
+                // Make API call for this specific area
+                $response = $this->callGeminiForArea($artifact, $area);
+                
+                // Apply JSON gate
+                $jsonResult = $this->applyJsonGate($response, $area, $areaResult);
+                
+                if ($jsonResult['success']) {
+                    // Successful AI result
+                    $areaResult->update([
+                        'status' => 'completed',
+                        'score' => $jsonResult['data']['score'],
+                        'justification' => $jsonResult['data']['justification'],
+                        'raw_response' => $jsonResult['raw_response'],
+                        'response_length' => $jsonResult['response_length'],
+                        'was_repaired' => $jsonResult['was_repaired'],
+                        'telemetry' => $this->generateAreaTelemetry($jsonResult, $attempt),
+                    ]);
+
+                    Log::info('AreaAssessor successful', [
+                        'session_id' => $session->id,
+                        'area' => $area,
+                        'score' => $jsonResult['data']['score'],
+                        'was_repaired' => $jsonResult['was_repaired']
+                    ]);
+
+                    return [
+                        'status' => 'completed',
+                        'score' => $jsonResult['data']['score'],
+                        'was_repaired' => $jsonResult['was_repaired']
+                    ];
+                }
+
+                // If not successful but not fatal, try again
+                if ($attempt < $maxRetries) {
+                    Log::warning('AreaAssessor retrying', [
+                        'session_id' => $session->id,
+                        'area' => $area,
+                        'attempt' => $attempt,
+                        'error' => $jsonResult['error'] ?? 'Unknown error'
+                    ]);
+                    continue;
+                }
+
+            } catch (Exception $e) {
+                Log::warning('AreaAssessor attempt failed', [
+                    'session_id' => $session->id,
+                    'area' => $area,
+                    'attempt' => $attempt,
+                    'error' => $e->getMessage()
+                ]);
+
+                if ($attempt >= $maxRetries) {
+                    break;
+                }
+            }
+        }
+
+        // All attempts failed - fall back to rubric
+        Log::warning('AreaAssessor falling back to rubric', [
+            'session_id' => $session->id,
+            'area' => $area,
+            'attempts' => $attempt
+        ]);
+
+        return $this->fallbackToRubric($session, $area, $areaResult);
+    }
+
+    /**
+     * Call Gemini API for a specific clinical area
+     */
+    private function callGeminiForArea(array $artifact, string $area): array
+    {
+        $prompt = $this->buildAreaPrompt($artifact, $area);
+        $schema = $this->getAreaSchema();
+
+        $response = Http::timeout(120)
+            ->withHeaders([
+                'Content-Type' => 'application/json',
+            ])
+            ->post($this->baseUrl . '/' . $this->model . ':generateContent?key=' . $this->apiKey, [
+                'contents' => [
+                    [
+                        'parts' => [
+                            [
+                                'text' => $prompt
+                            ]
+                        ]
+                    ]
+                ],
+                'generationConfig' => [
+                    'temperature' => 0.1,
+                    'topK' => 1,
+                    'topP' => 1,
+                    'maxOutputTokens' => 900,
+                    'responseMimeType' => 'application/json',
+                    'responseSchema' => $schema,
+                ],
+            ]);
+
+        if (!$response->successful()) {
+            throw new Exception('Gemini API error: ' . $response->status() . ' - ' . $response->body());
+        }
+
+        $data = $response->json();
+        $text = $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
+
+        return [
+            'text' => $text,
+            'response_length' => strlen($text),
+            'status_code' => $response->status()
+        ];
+    }
+
+    /**
+     * Apply strict JSON validation with repair capability
+     */
+    private function applyJsonGate(array $response, string $area, AiAssessmentAreaResult $areaResult): array
+    {
+        $text = $response['text'];
+        $wasRepaired = false;
+
+        // Step 1: Validate syntax with json_validate()
+        if (!json_validate($text)) {
+            Log::info('JSON validation failed, attempting repair', [
+                'area' => $area,
+                'area_result_id' => $areaResult->id,
+                'text_preview' => substr($text, 0, 200)
+            ]);
+
+            // Step 2: Attempt repair
+            $repairedText = $this->repairJson($text);
+            if ($repairedText && json_validate($repairedText)) {
+                $text = $repairedText;
+                $wasRepaired = true;
+                Log::info('JSON repair successful', [
+                    'area' => $area,
+                    'area_result_id' => $areaResult->id
+                ]);
+            } else {
+                Log::error('JSON repair failed', [
+                    'area' => $area,
+                    'area_result_id' => $areaResult->id,
+                    'original_text' => substr($text, 0, 500)
+                ]);
+                return [
+                    'success' => false,
+                    'error' => 'JSON repair failed',
+                    'raw_response' => $response
+                ];
+            }
+        }
+
+        // Step 3: Decode JSON
+        $decoded = json_decode($text, true);
+        if ($decoded === null) {
+            return [
+                'success' => false,
+                'error' => 'JSON decode failed after repair',
+                'raw_response' => $response
+            ];
+        }
+
+        // Step 4: Validate against schema
+        if (!$this->validateAreaSchema($decoded)) {
+            Log::error('Schema validation failed', [
+                'area' => $area,
+                'area_result_id' => $areaResult->id,
+                'decoded' => $decoded
+            ]);
+            return [
+                'success' => false,
+                'error' => 'Schema validation failed',
+                'raw_response' => $response
+            ];
+        }
+
+        // Step 5: Clamp scores if needed
+        $maxScore = AiAssessmentAreaResult::CLINICAL_AREAS[$area]['max_score'];
+        if ($decoded['score'] > $maxScore) {
+            Log::warning('Score clamping applied', [
+                'area' => $area,
+                'original_score' => $decoded['score'],
+                'max_score' => $maxScore
+            ]);
+            $decoded['score'] = $maxScore;
+        }
+
+        return [
+            'success' => true,
+            'data' => $decoded,
+            'was_repaired' => $wasRepaired,
+            'raw_response' => $response,
+            'response_length' => $response['response_length']
+        ];
+    }
+
+    /**
+     * Repair malformed JSON
+     */
+    private function repairJson(string $text): ?string
+    {
+        try {
+            // Clean up common issues
+            $cleaned = trim($text);
+            
+            // Remove markdown code blocks
+            $cleaned = preg_replace('/^```json\s*/', '', $cleaned);
+            $cleaned = preg_replace('/\s*```$/', '', $cleaned);
+            
+            // Remove trailing commas
+            $cleaned = preg_replace('/,\s*}/', '}', $cleaned);
+            $cleaned = preg_replace('/,\s*]/', ']', $cleaned);
+            
+            // Try to fix incomplete JSON by ensuring proper closing
+            if (substr_count($cleaned, '{') > substr_count($cleaned, '}')) {
+                $cleaned .= '}';
+            }
+            
+            return $cleaned;
+        } catch (Exception $e) {
+            Log::error('JSON repair exception', ['error' => $e->getMessage()]);
+            return null;
+        }
+    }
+
+    /**
+     * Fall back to rubric scoring for this area
+     */
+    private function fallbackToRubric(OsceSession $session, string $area, AiAssessmentAreaResult $areaResult): array
+    {
+        $config = config('osce_scoring');
+        
+        // Find the matching criterion in the rubric
+        $rubricScore = 0;
+        $maxScore = AiAssessmentAreaResult::CLINICAL_AREAS[$area]['max_score'];
+        $justification = "AI assessment failed. Using rubric-based fallback scoring.";
+
+        // Compute rubric score for this specific area
+        if ($config && isset($config['criteria'])) {
+            foreach ($config['criteria'] as $criterion) {
+                if ($this->mapAreaToCriterion($area) === $criterion['key']) {
+                    $rubricScore = $this->aiAssessorService->computeCriterionScore(
+                        $criterion, 
+                        $session, 
+                        $session->osceCase, 
+                        $config
+                    );
+                    break;
+                }
+            }
+        }
+
+        // Scale the score to match our area's max score
+        if ($maxScore !== ($criterion['max'] ?? 10)) {
+            $rubricScore = (int) round(($rubricScore / ($criterion['max'] ?? 10)) * $maxScore);
+        }
+
+        $areaResult->update([
+            'status' => 'fallback',
+            'score' => $rubricScore,
+            'justification' => $justification,
+            'telemetry' => [
+                'fallback_reason' => 'AI assessment failed after all retries',
+                'rubric_method' => 'computed',
+                'original_rubric_score' => $rubricScore,
+                'scaled_to_max' => $maxScore
+            ]
+        ]);
+
+        return [
+            'status' => 'fallback',
+            'score' => $rubricScore
+        ];
+    }
+
+    /**
+     * Build prompt for a specific clinical area
+     */
+    private function buildAreaPrompt(array $artifact, string $area): string
+    {
+        $artifactJson = json_encode($artifact, JSON_PRETTY_PRINT);
+        $areaConfig = AiAssessmentAreaResult::CLINICAL_AREAS[$area];
+        
+        $prompts = [
+            'history' => $this->buildHistoryPrompt($artifactJson, $areaConfig),
+            'exam' => $this->buildExamPrompt($artifactJson, $areaConfig),
+            'investigations' => $this->buildInvestigationsPrompt($artifactJson, $areaConfig),
+            'differential_diagnosis' => $this->buildDifferentialDiagnosisPrompt($artifactJson, $areaConfig),
+            'management' => $this->buildManagementPrompt($artifactJson, $areaConfig),
+        ];
+
+        return $prompts[$area] ?? $this->buildGenericPrompt($artifactJson, $area, $areaConfig);
+    }
+
+    private function buildHistoryPrompt(string $artifactJson, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing HISTORY-TAKING performance in an OSCE session.
+
+Analyze the detailed session data and provide a focused assessment of the student's history-taking skills.
+
+Session Data:
+{$artifactJson}
+
+Assessment Focus: HISTORY-TAKING ONLY
+- Analyze detailed_analysis.communication.conversation_flow for specific user messages
+- Evaluate systematic approach, question types, and thoroughness
+- Check coverage of case.key_history_points
+- Consider quality of questioning technique
+
+Scoring Guidelines (0-{$config['max_score']} points):
+- 0-8: Poor/minimal history taking
+- 9-12: Basic history taking
+- 13-16: Good systematic history
+- 17-20: Excellent comprehensive history
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis with specific quotes from user messages, maximum 1200 characters>"
+}
+
+Be specific and quote actual user messages when possible. Focus only on history-taking performance.
+PROMPT;
+    }
+
+    private function buildExamPrompt(string $artifactJson, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing PHYSICAL EXAMINATION performance in an OSCE session.
+
+Analyze the detailed session data and provide a focused assessment of the student's examination skills.
+
+Session Data:
+{$artifactJson}
+
+Assessment Focus: PHYSICAL EXAMINATION ONLY
+- Analyze detailed_analysis.examinations.examination_timeline for performed examinations
+- Check detailed_analysis.examinations.critical_examinations_status for missing critical exams
+- Evaluate systematic approach and thoroughness
+- Review findings documentation and body systems examined
+
+Scoring Guidelines (0-{$config['max_score']} points):
+- 0-6: No/minimal examination
+- 7-9: Partial examination
+- 10-12: Good systematic examination
+- 13-15: Comprehensive thorough examination
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis with specific examination findings and missing elements, maximum 1200 characters>"
+}
+
+Be specific about which examinations were performed and which critical ones were missed.
+PROMPT;
+    }
+
+    private function buildInvestigationsPrompt(string $artifactJson, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing INVESTIGATIONS performance in an OSCE session.
+
+Analyze the detailed session data and provide a focused assessment of the student's investigation ordering.
+
+Session Data:
+{$artifactJson}
+
+Assessment Focus: INVESTIGATIONS ONLY
+- Analyze detailed_analysis.tests.test_ordering_timeline for ordered tests with costs and timing
+- Check detailed_analysis.tests.required_tests_status for missing required tests
+- Review detailed_analysis.tests.appropriate_tests_status for test appropriateness
+- Evaluate detailed_analysis.tests.contraindicated_tests_ordered for inappropriate orders
+- Consider cost management and budget efficiency
+
+Scoring Guidelines (0-{$config['max_score']} points):
+- 0-8: Poor test selection/management
+- 9-12: Adequate investigation approach
+- 13-16: Good appropriate testing
+- 17-20: Excellent investigation strategy
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis with specific tests ordered, costs, appropriateness, and missing elements, maximum 1200 characters>"
+}
+
+Be specific about test names, costs, timing, and appropriateness.
+PROMPT;
+    }
+
+    private function buildDifferentialDiagnosisPrompt(string $artifactJson, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing DIFFERENTIAL DIAGNOSIS reasoning in an OSCE session.
+
+Analyze the detailed session data and provide a focused assessment of the student's diagnostic reasoning.
+
+Session Data:
+{$artifactJson}
+
+Assessment Focus: DIFFERENTIAL DIAGNOSIS ONLY
+- Analyze conversation flow for diagnostic thinking and hypothesis generation
+- Evaluate integration of history, examination, and investigation findings
+- Consider systematic approach to differential diagnosis
+- Assess clinical reasoning process and diagnostic accuracy
+
+Scoring Guidelines (0-{$config['max_score']} points):
+- 0-6: No/poor diagnostic reasoning
+- 7-9: Basic diagnostic thinking
+- 10-12: Good differential consideration
+- 13-15: Excellent diagnostic reasoning
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis of diagnostic reasoning process with evidence from session, maximum 1200 characters>"
+}
+
+Focus specifically on diagnostic thinking and differential diagnosis consideration.
+PROMPT;
+    }
+
+    private function buildManagementPrompt(string $artifactJson, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing MANAGEMENT planning in an OSCE session.
+
+Analyze the detailed session data and provide a focused assessment of the student's management approach.
+
+Session Data:
+{$artifactJson}
+
+Assessment Focus: MANAGEMENT ONLY
+- Analyze conversation for management planning and therapeutic discussions
+- Evaluate treatment approach, safety considerations, and follow-up planning
+- Consider appropriateness of proposed interventions
+- Assess understanding of management principles
+
+Scoring Guidelines (0-{$config['max_score']} points):
+- 0-6: No/poor management planning
+- 7-9: Basic management approach
+- 10-12: Good management planning
+- 13-15: Excellent comprehensive management
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis of management approach with specific evidence, maximum 1200 characters>"
+}
+
+Focus specifically on management planning and therapeutic reasoning.
+PROMPT;
+    }
+
+    private function buildGenericPrompt(string $artifactJson, string $area, array $config): string
+    {
+        return <<<PROMPT
+You are an expert medical examiner assessing {$area} performance in an OSCE session.
+
+Session Data:
+{$artifactJson}
+
+You must return ONLY a JSON object with this exact structure:
+{
+  "score": <integer between 0 and {$config['max_score']}>,
+  "max_score": {$config['max_score']},
+  "justification": "<detailed analysis maximum 1200 characters>"
+}
+PROMPT;
+    }
+
+    /**
+     * Get JSON schema for area assessment
+     */
+    private function getAreaSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'score' => ['type' => 'integer'],
+                'max_score' => ['type' => 'integer'],
+                'justification' => ['type' => 'string', 'maxLength' => 1200]
+            ],
+            'required' => ['score', 'max_score', 'justification']
+        ];
+    }
+
+    /**
+     * Validate area assessment schema
+     */
+    private function validateAreaSchema(array $data): bool
+    {
+        $required = ['score', 'max_score', 'justification'];
+        
+        foreach ($required as $field) {
+            if (!isset($data[$field])) {
+                return false;
+            }
+        }
+
+        if (!is_int($data['score']) || !is_int($data['max_score'])) {
+            return false;
+        }
+
+        if (!is_string($data['justification']) || strlen($data['justification']) > 1200) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Map clinical area to rubric criterion key
+     */
+    private function mapAreaToCriterion(string $area): string
+    {
+        return match ($area) {
+            'history' => 'history',
+            'exam' => 'exam',
+            'investigations' => 'investigations',
+            'differential_diagnosis' => 'diagnosis',
+            'management' => 'management',
+            default => $area
+        };
+    }
+
+    /**
+     * Generate telemetry for area processing
+     */
+    private function generateAreaTelemetry(array $jsonResult, int $attempts): array
+    {
+        return [
+            'attempts' => $attempts,
+            'was_repaired' => $jsonResult['was_repaired'],
+            'response_length' => $jsonResult['response_length'],
+            'raw_response_preview' => substr($jsonResult['raw_response']['text'] ?? '', 0, 500),
+            'processing_method' => 'ai_assessment',
+            'json_gate_passed' => true,
+        ];
+    }
+}

--- a/webapp/app/Services/ResultReducer.php
+++ b/webapp/app/Services/ResultReducer.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AiAssessmentRun;
+use App\Models\AiAssessmentAreaResult;
+use Illuminate\Support\Facades\Log;
+
+class ResultReducer
+{
+    /**
+     * Aggregate area results into a final assessment
+     */
+    public function aggregateResults(AiAssessmentRun $assessmentRun): array
+    {
+        Log::info('ResultReducer starting aggregation', [
+            'run_id' => $assessmentRun->id,
+            'session_id' => $assessmentRun->osce_session_id
+        ]);
+
+        $areaResults = $assessmentRun->areaResults;
+        
+        if ($areaResults->isEmpty()) {
+            Log::error('No area results found for aggregation', [
+                'run_id' => $assessmentRun->id
+            ]);
+            
+            return $this->createEmptyResult();
+        }
+
+        // Calculate totals
+        $totalScore = $areaResults->sum('score');
+        $maxPossibleScore = $areaResults->sum('max_score');
+        
+        // Build clinical areas array
+        $clinicalAreas = [];
+        foreach ($areaResults as $result) {
+            $clinicalAreas[] = [
+                'area' => $result->area_display_name,
+                'key' => $result->clinical_area,
+                'score' => $result->score ?? 0,
+                'max_score' => $result->max_score,
+                'justification' => $result->justification ?? 'No assessment available',
+                'status' => $result->status,
+                'badge_color' => $result->badge_color,
+                'badge_text' => $result->badge_text,
+                'was_repaired' => $result->was_repaired,
+                'attempts' => $result->attempts,
+                'method' => $this->getAssessmentMethod($result),
+            ];
+        }
+
+        // Sort clinical areas by a predefined order
+        usort($clinicalAreas, function ($a, $b) {
+            $order = ['history', 'exam', 'investigations', 'differential_diagnosis', 'management'];
+            $aIndex = array_search($a['key'], $order);
+            $bIndex = array_search($b['key'], $order);
+            return $aIndex <=> $bIndex;
+        });
+
+        // Generate overall feedback
+        $overallFeedback = $this->generateOverallFeedback($areaResults, $totalScore, $maxPossibleScore);
+        
+        // Generate safety concerns
+        $safetyConcerns = $this->generateSafetyConcerns($areaResults);
+        
+        // Generate recommendations
+        $recommendations = $this->generateRecommendations($areaResults);
+
+        // Apply sanity checks
+        $this->applySanityChecks($clinicalAreas, $totalScore, $maxPossibleScore);
+
+        $result = [
+            'total_score' => $totalScore,
+            'max_possible_score' => $maxPossibleScore,
+            'assessment_type' => 'detailed_clinical_areas_assessment',
+            'clinical_areas' => $clinicalAreas,
+            'overall_feedback' => $overallFeedback,
+            'safety_concerns' => $safetyConcerns,
+            'recommendations' => $recommendations,
+            'model_info' => [
+                'name' => config('services.gemini.model', 'gemini-2.5-flash'),
+                'temperature' => 0.1,
+                'assessment_approach' => 'map_reduce_clinical_areas',
+                'total_areas' => $areaResults->count(),
+                'ai_areas' => $areaResults->where('status', 'completed')->count(),
+                'fallback_areas' => $areaResults->where('status', 'fallback')->count(),
+                'failed_areas' => $areaResults->where('status', 'failed')->count(),
+                'repaired_areas' => $areaResults->where('was_repaired', true)->count(),
+            ],
+            'processing_metadata' => [
+                'run_id' => $assessmentRun->id,
+                'processing_time' => $assessmentRun->completed_at?->diffInSeconds($assessmentRun->started_at),
+                'has_fallbacks' => $areaResults->where('status', 'fallback')->isNotEmpty(),
+                'success_rate' => $areaResults->count() > 0 ? 
+                    round(($areaResults->whereIn('status', ['completed', 'fallback'])->count() / $areaResults->count()) * 100, 1) : 0,
+            ]
+        ];
+
+        Log::info('ResultReducer aggregation completed', [
+            'run_id' => $assessmentRun->id,
+            'total_score' => $totalScore,
+            'max_possible_score' => $maxPossibleScore,
+            'success_rate' => $result['processing_metadata']['success_rate'],
+            'has_fallbacks' => $result['processing_metadata']['has_fallbacks']
+        ]);
+
+        return $result;
+    }
+
+    /**
+     * Create empty result for error cases
+     */
+    private function createEmptyResult(): array
+    {
+        return [
+            'total_score' => 0,
+            'max_possible_score' => 85,
+            'assessment_type' => 'detailed_clinical_areas_assessment',
+            'clinical_areas' => [],
+            'overall_feedback' => 'Assessment could not be completed due to processing errors.',
+            'safety_concerns' => ['Assessment system failure - results may not reflect actual performance'],
+            'recommendations' => ['Please retry the assessment or contact support'],
+            'model_info' => [
+                'name' => 'error',
+                'assessment_approach' => 'failed',
+            ],
+            'processing_metadata' => [
+                'has_fallbacks' => false,
+                'success_rate' => 0,
+            ]
+        ];
+    }
+
+    /**
+     * Generate overall feedback based on area results
+     */
+    private function generateOverallFeedback(
+        $areaResults, 
+        int $totalScore, 
+        int $maxPossibleScore
+    ): string {
+        $percentage = $maxPossibleScore > 0 ? round(($totalScore / $maxPossibleScore) * 100, 1) : 0;
+        
+        $completedAreas = $areaResults->where('status', 'completed')->count();
+        $fallbackAreas = $areaResults->where('status', 'fallback')->count();
+        $failedAreas = $areaResults->where('status', 'failed')->count();
+        
+        $feedback = "Overall performance: {$totalScore}/{$maxPossibleScore} ({$percentage}%). ";
+        
+        if ($completedAreas > 0) {
+            $feedback .= "AI analysis completed for {$completedAreas} clinical areas. ";
+        }
+        
+        if ($fallbackAreas > 0) {
+            $feedback .= "Rubric-based assessment used for {$fallbackAreas} areas due to AI processing limitations. ";
+        }
+        
+        if ($failedAreas > 0) {
+            $feedback .= "Assessment failed for {$failedAreas} areas. ";
+        }
+
+        // Add performance tier feedback
+        if ($percentage >= 85) {
+            $feedback .= "Excellent overall performance across clinical areas.";
+        } elseif ($percentage >= 75) {
+            $feedback .= "Good performance with some areas for improvement.";
+        } elseif ($percentage >= 65) {
+            $feedback .= "Adequate performance with several areas needing attention.";
+        } else {
+            $feedback .= "Performance below expectations - significant improvement needed.";
+        }
+
+        return $feedback;
+    }
+
+    /**
+     * Generate safety concerns from area results
+     */
+    private function generateSafetyConcerns($areaResults): array
+    {
+        $concerns = [];
+        
+        // Check for very low scores in critical areas
+        foreach ($areaResults as $result) {
+            if (!$result->score || $result->max_score === 0) {
+                continue;
+            }
+            
+            $percentage = ($result->score / $result->max_score) * 100;
+            
+            if ($percentage < 40) {
+                $concerns[] = "Critical concern in {$result->area_display_name}: Very low performance ({$result->score}/{$result->max_score})";
+            }
+        }
+        
+        // Check for failed assessments
+        $failedAreas = $areaResults->where('status', 'failed');
+        foreach ($failedAreas as $failed) {
+            $concerns[] = "Assessment system failure in {$failed->area_display_name} - manual review required";
+        }
+        
+        if (empty($concerns)) {
+            // Add generic safety check based on overall performance
+            $totalScore = $areaResults->sum('score');
+            $maxScore = $areaResults->sum('max_score');
+            if ($maxScore > 0 && ($totalScore / $maxScore) < 0.5) {
+                $concerns[] = "Overall performance below safe practice threshold - comprehensive review recommended";
+            }
+        }
+        
+        return $concerns;
+    }
+
+    /**
+     * Generate recommendations based on area results
+     */
+    private function generateRecommendations($areaResults): array
+    {
+        $recommendations = [];
+        
+        // Area-specific recommendations based on performance
+        foreach ($areaResults as $result) {
+            if (!$result->score || $result->max_score === 0) {
+                continue;
+            }
+            
+            $percentage = ($result->score / $result->max_score) * 100;
+            
+            if ($percentage < 60) {
+                $recommendations[] = $this->getAreaRecommendation($result->clinical_area, 'poor');
+            } elseif ($percentage < 80) {
+                $recommendations[] = $this->getAreaRecommendation($result->clinical_area, 'needs_improvement');
+            }
+        }
+        
+        // Add fallback recommendations
+        $fallbackCount = $areaResults->where('status', 'fallback')->count();
+        if ($fallbackCount > 0) {
+            $recommendations[] = "Some assessments used fallback scoring - consider retrying for more detailed AI feedback";
+        }
+        
+        if (empty($recommendations)) {
+            $recommendations[] = "Continue practicing to maintain and improve clinical skills";
+        }
+        
+        return array_unique($recommendations);
+    }
+
+    /**
+     * Get specific recommendations for each clinical area
+     */
+    private function getAreaRecommendation(string $area, string $level): string
+    {
+        $recommendations = [
+            'history' => [
+                'poor' => 'Focus on systematic history-taking approach and comprehensive questioning techniques',
+                'needs_improvement' => 'Practice more thorough history-taking with attention to key clinical details'
+            ],
+            'exam' => [
+                'poor' => 'Review physical examination techniques and systematic approach to clinical examination',
+                'needs_improvement' => 'Improve examination completeness and focus on critical examination skills'
+            ],
+            'investigations' => [
+                'poor' => 'Study appropriate investigation selection and cost-effective testing strategies',
+                'needs_improvement' => 'Refine investigation ordering with better clinical reasoning and cost awareness'
+            ],
+            'differential_diagnosis' => [
+                'poor' => 'Strengthen diagnostic reasoning skills and differential diagnosis development',
+                'needs_improvement' => 'Improve clinical reasoning and systematic approach to diagnosis'
+            ],
+            'management' => [
+                'poor' => 'Review management principles and therapeutic decision-making processes',
+                'needs_improvement' => 'Enhance management planning with focus on comprehensive patient care'
+            ],
+        ];
+        
+        return $recommendations[$area][$level] ?? "Focus on improving performance in {$area}";
+    }
+
+    /**
+     * Apply sanity checks and corrections
+     */
+    private function applySanityChecks(array &$clinicalAreas, int &$totalScore, int $maxPossibleScore): void
+    {
+        $corrected = false;
+        
+        foreach ($clinicalAreas as &$area) {
+            // Clamp scores to valid ranges
+            if ($area['score'] < 0) {
+                $area['score'] = 0;
+                $corrected = true;
+            }
+            
+            if ($area['score'] > $area['max_score']) {
+                $area['score'] = $area['max_score'];
+                $corrected = true;
+            }
+        }
+        
+        // Recalculate total if corrections were made
+        if ($corrected) {
+            $totalScore = array_sum(array_column($clinicalAreas, 'score'));
+            
+            Log::warning('Sanity check corrections applied', [
+                'corrected_total_score' => $totalScore,
+                'max_possible_score' => $maxPossibleScore
+            ]);
+        }
+    }
+
+    /**
+     * Determine assessment method for result
+     */
+    private function getAssessmentMethod(AiAssessmentAreaResult $result): string
+    {
+        return match ($result->status) {
+            'completed' => $result->was_repaired ? 'ai_repaired' : 'ai',
+            'fallback' => 'rubric',
+            'failed' => 'failed',
+            default => 'unknown'
+        };
+    }
+}

--- a/webapp/database/migrations/2025_08_29_014752_create_ai_assessment_runs_table.php
+++ b/webapp/database/migrations/2025_08_29_014752_create_ai_assessment_runs_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_assessment_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('osce_session_id')->constrained()->onDelete('cascade');
+            $table->enum('status', ['pending', 'in_progress', 'completed', 'failed'])->default('pending');
+            $table->json('final_result')->nullable(); // The aggregated assessment result
+            $table->integer('total_score')->nullable();
+            $table->integer('max_possible_score')->nullable();
+            $table->text('error_message')->nullable();
+            $table->json('telemetry')->nullable(); // Store telemetry data for debugging
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['osce_session_id', 'status']);
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_assessment_runs');
+    }
+};

--- a/webapp/database/migrations/2025_08_29_014826_create_ai_assessment_area_results_table.php
+++ b/webapp/database/migrations/2025_08_29_014826_create_ai_assessment_area_results_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_assessment_area_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ai_assessment_run_id')->constrained()->onDelete('cascade');
+            $table->string('clinical_area'); // 'history', 'exam', 'investigations', 'differential_diagnosis', 'management'
+            $table->enum('status', ['pending', 'in_progress', 'completed', 'failed', 'fallback'])->default('pending');
+            $table->integer('score')->nullable();
+            $table->integer('max_score');
+            $table->text('justification')->nullable();
+            $table->json('raw_response')->nullable(); // Store the raw AI response
+            $table->integer('response_length')->nullable();
+            $table->integer('attempts')->default(0);
+            $table->boolean('was_repaired')->default(false);
+            $table->text('error_message')->nullable();
+            $table->json('telemetry')->nullable(); // Logs: attempts, repair info, etc.
+            $table->timestamps();
+
+            $table->index(['ai_assessment_run_id', 'clinical_area']);
+            $table->index(['ai_assessment_run_id', 'status']);
+            $table->unique(['ai_assessment_run_id', 'clinical_area']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_assessment_area_results');
+    }
+};

--- a/webapp/routes/web.php
+++ b/webapp/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware([
 	
 	// OSCE Assessment routes
 	Route::post('api/osce/sessions/{session}/assess', [OsceAssessmentController::class, 'assess'])->name('osce.assess');
+	Route::get('api/osce/sessions/{session}/status', [OsceAssessmentController::class, 'status'])->name('osce.status');
 	Route::get('api/osce/sessions/{session}/results', [OsceAssessmentController::class, 'results'])->name('osce.results');
 	Route::get('osce/results/{session}', [OsceAssessmentController::class, 'show'])->name('osce.results.show');
 	// Optional scoring alias: follows the same gating as results


### PR DESCRIPTION
Read FINAL_ASSESSMENT_REPORT.md for context
Objective:
Stop large, malformed JSON from breaking the OSCE AI assessment flow by splitting into per-clinical-area calls, applying strict JSON gates, and implementing progressive fallback.
Requirements
1. Split Assessment Generation (map → reduce)
Define 5 clinical areas: history, exam, investigations, differential diagnosis, management.
Each area = one Gemini API call.
Use responseMimeType: application/json and a per-area schema:
{
  "type": "object",
  "properties": {
    "score": {"type": "integer"},
    "max_score": {"type": "integer"},
    "justification": {"type": "string", "maxLength": 1200}
  },
  "required": ["score","max_score","justification"]
}
maxOutputTokens: ~900 per call.
2. Orchestrator Job
Queue job AiAssessorOrchestrator(sessionId, force) runs through each area sequentially.
Store partial results as they arrive in ai_assessment_area_results.
Reducer aggregates totals and assembles final JSON into ai_assessment_runs.
3. JSON Gate (Strict + Repair)
On each response:
Validate syntax with json_validate().
If invalid → run repair once (adhocore/json-fixer or regex clean).
Decode.
Validate against schema (use Opis JSON Schema).
If still invalid → retry once.
If still invalid after retry → mark area as rubric fallback only.
4. Progressive Fallback
Strict JSON success → ✅ AI result.
Repaired JSON success → ✅ AI result + mark was_repaired=true.
If both fail → regenerate once.
If still invalid → use rubric fallback for that area only, not the whole assessment.
5. Telemetry & Logging
Log per area:
response length, attempts, status, was_repaired, first 500 chars of raw (before/after repair).
Clamp: if score > max_score, auto-correct and flag anomaly.
Final reducer produces:
{
  "total_score": <int>,
  "max_possible_score": <int>,
  "assessment_type": "detailed_clinical_areas_assessment",
  "clinical_areas": [ ... per-area results ... ]
}
6. Frontend UX
Poll run status until complete.
Display per-area badges: AI (green), AI repaired (amber), Rubric (gray).
If any fallbacks, show message: “Some sections used rubric due to invalid AI output.”
Deliverables
Updated services:
AiAssessorOrchestrator (map → reduce runner)
AreaAssessor (one call + JSON gate)
ResultReducer (assemble + sanity checks)
Migration: ai_assessment_runs, ai_assessment_area_results.
Integration in existing /assess controller with { runId } returned.
Frontend polling + badge display.
Acceptance Criteria:
Large responses no longer break JSON parsing.
Failed areas fall back to rubric individually, not globally.
Logs show telemetry for debugging.
User sees mixed AI/rubric results clearly.