### PR TITLE
Ganti UI → Buat dokumentasi baru buat migrate semua fungsi ke React (vibe-kanban)

### DIFF
--- a/.claude/kanban/migrate-react.prompt.md
+++ b/.claude/kanban/migrate-react.prompt.md
@@ -1,0 +1,69 @@
+Title: Migration Plan — Move Inertia Frontend from Vue 3 to React (Vibe UI KIT) for OSCE app
+
+Purpose
+- Migrate the SPA frontend to React to standardize on Vibe UI KIT, simplify component reuse, and accelerate UI iteration while keeping Laravel + Inertia architecture and backend services unchanged.
+
+Scope
+- Convert Inertia pages and layouts from Vue to React incrementally.
+- Keep backend routes, controllers, jobs, and services as-is; only adjust Inertia responses if page component paths change.
+- Maintain Tailwind v4 styling; replace shadcn-vue with Vibe UI KIT React components.
+- Ensure dev workflow remains `composer dev` / `npm run dev` with Vite HMR.
+
+Out of Scope
+- Backend data models, migrations, and queue behaviors.
+- Changing Gemini service contracts or endpoints.
+- SSR enablement (keep disabled during migration).
+
+Architecture & Current State
+- Backend: Laravel 12, Inertia Laravel 2, queue workers (database), SQLite in dev.
+- Frontend: Mixed stack. React is configured and bootstrapped at `resources/js/app.jsx` resolving React pages from `resources/js/pages/**/*.jsx`. Legacy Vue pages are under `resources/js/pages-vue-backup` and backup files like `app.ts.vue-backup`.
+- Vite: `vite.config.ts` loads `@vitejs/plugin-react`, Tailwind, and `laravel-vite-plugin`. Input: `resources/js/app.jsx`. HMR/ports configured via `.env`.
+- UI Kit: Temporary alias `@vibe-kanban/ui-kit` present in Vite config; React pages should import components from this kit.
+
+Key Files & References
+- Frontend entry: `webapp/resources/js/app.jsx`
+- React pages root: `webapp/resources/js/pages/`
+- Layouts and components: `webapp/resources/js/layouts`, `webapp/resources/js/components`
+- Vite config: `webapp/vite.config.ts`
+- NPM scripts: `webapp/package.json`
+- Laravel routes: `webapp/routes/web.php`
+- Inertia controllers: under `webapp/app/Http/Controllers/*` (e.g., `OsceController`, `OsceAssessmentController`, `LandingController`, `DashboardController`)
+
+Constraints
+- Use Inertia React (`@inertiajs/react`) for navigation and forms; avoid raw fetch.
+- Use Vibe UI KIT React components; keep Tailwind classes tidy.
+- Do not mix Vue and React within a page. Full-page swaps only.
+- Keep ports consistent: Laravel 8001, Vite 5173 (configurable via `.env`).
+- No client-side Gemini calls; use existing Laravel endpoints.
+
+Error Handling & Logging
+- Surface server-side validation/errors via Inertia props.
+- Log Gemini and assessment errors on the server (existing services). Do not expose API keys client-side.
+- Guard optional tooling in dev scripts (pail) to avoid crashes in environments without it.
+
+Acceptance Criteria
+1) App boots via React entry (`resources/js/app.jsx`) and all targeted pages render using React components.
+2) Navigation, forms, and state behave the same as legacy pages with Inertia React.
+3) New UI uses Vibe UI KIT components; Tailwind styles consistent; no shadcn-vue usage on migrated pages.
+4) `vite.config.ts` only requires React plugin for migrated build; SSR stays disabled.
+5) No Vue runtime errors in console on migrated routes; Vue-only deps can be removed in cleanup.
+6) Dev scripts and `composer dev` continue to run Laravel, queues, logs, and Vite smoothly.
+
+Phased Migration (High-Level)
+- Phase 0 — Prep: Confirm React boot, align Vite alias, baseline layout.
+- Phase 1 — Shell: Convert base layouts, navbar/sidebar, and route skeletons.
+- Phase 2 — OSCE Core: Migrate `osce` index and chat pages.
+- Phase 3 — Assessment: Migrate assessment start/status/results views.
+- Phase 4 — Remaining pages: Dashboard, landing, rationalization, settings.
+- Phase 5 — Cleanup: Remove Vue deps, delete backups, simplify Vite config.
+
+Risks & Mitigations
+- Mixed-kit UX drift → Define a minimal design token bridge; prefer Vibe UI KIT defaults.
+- Large PRs → Ship per-route or per-feature PRs; keep diffs contained.
+- Inertia prop drift → Use existing controller responses; only adjust component names/paths.
+
+Quick Commands
+- Dev: `composer dev` (Laravel, queue, logs, Vite)
+- Frontend: `npm run dev` / `npm run build`
+- Tests: `composer test`
+

--- a/.claude/kanban/migrate-react.todo.md
+++ b/.claude/kanban/migrate-react.todo.md
@@ -1,0 +1,48 @@
+Feature Slug: migrate-react
+
+Objective
+- Complete the migration of Inertia frontend from Vue to React using Vibe UI KIT while keeping backend stable. Ship in small, verifiable phases.
+
+Phase 0 — Prep (baseline)
+- [ ] Verify React boot works: `resources/js/app.jsx` resolves from `resources/js/pages/**/*.jsx` and renders a sample page.
+- [ ] Create/verify a base React Layout (`resources/js/layouts/AppLayout.jsx`) with header/sidebar placeholders.
+- [ ] Ensure Vite alias for `@vibe-kanban/ui-kit` points to the local kit or package; import a Button to confirm styling.
+- [ ] Document ports in `.env` (`VITE_DEV_PORT=5173`, HMR host if needed).
+
+Phase 1 — Shell & Navigation
+- [ ] Implement AppShell components using Vibe UI KIT (Navbar, Sidebar, Container).
+- [ ] Wire up `<Link>` navigation via Inertia React; add a simple route list page if needed.
+- [ ] Migrate landing and dashboard pages to React with minimal content.
+
+Phase 2 — OSCE Core
+- [ ] Migrate `GET /osce` page (index/board) to React: load cases and sessions via existing endpoints; render with Vibe UI components.
+- [ ] Migrate `GET /osce/chat/{session}` to React: chat UI with message list, input, send action hitting `POST /api/osce/chat/message`.
+- [ ] Confirm timers and session actions use Inertia/axios via controllers (no direct Gemini calls).
+
+Phase 3 — Assessment
+- [ ] Migrate assess trigger: `POST /api/osce/sessions/{session}/assess` (button + progress state).
+- [ ] Migrate status/result views: `GET /api/osce/sessions/{session}/status`, `GET /api/osce/sessions/{session}/results`, `GET /osce/results/{session}`.
+- [ ] Use Vibe UI components for tables/cards; keep relative time utilities simple.
+
+Phase 4 — Rationalization & Settings
+- [ ] Migrate `GET /osce/rationalization/{session}` to React.
+- [ ] Migrate settings/profile pages referenced by `routes/settings.php` to React where applicable.
+
+Phase 5 — Cleanup & Deps
+- [ ] Remove Vue-only deps: `@inertiajs/vue3`, `@vitejs/plugin-vue`, `vue`, `@tiptap/vue-3`, `lucide-vue-next`, etc. (after all pages migrated).
+- [ ] Remove `resources/js/pages-vue-backup`, `app.ts.vue-backup`, `ssr.ts.vue-backup`.
+- [ ] Simplify `vite.config.ts` to React-only aliases; keep Tailwind and Laravel plugin.
+- [ ] Run `npm prune && npm dedupe` and verify builds.
+
+Verification Checklist
+- [ ] All routes in `webapp/routes/web.php` render React pages without console errors.
+- [ ] No Vue runtime present in prod build (`dist` contains no `vue` chunks).
+- [ ] `composer dev` starts server, queue, logs, and Vite without failures.
+- [ ] UI components are from Vibe UI KIT; Tailwind styles pass visual smoke check.
+- [ ] PHP tests pass: `composer test`.
+
+Notes & Tips
+- Keep PRs small (per route or feature) to speed reviews.
+- Use Inertia partial reloads for infinite scroll and updates.
+- Keep Gemini calls server-side only; React pages consume existing JSON/Inertia props.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Primary app: `webapp/` (Laravel + Vue via Inertia). Key dirs: `app/`, `resources/`, `routes/`, `database/`, `public/`, `tests/`.
+- Primary app: `webapp/` (Laravel + Inertia; Vue today, React in migration). Key dirs: `app/`, `resources/`, `routes/`, `database/`, `public/`, `tests/`.
 - Legacy CLI: repository root (Node.js ESM). Entry: `app.js`; helpers: `utils/`; sample data: `cases/`; tests: `test/`.
 - Docs & config: `README.md`, `INTEGRATION_TESTS_SUMMARY.md`, `webapp/GEMINI.md`, `.env.example` (root and `webapp/`). Never commit real secrets.
 
 ## Architecture Overview
-- Layers: Backend (Laravel), Frontend (Vue via Inertia), Data (MySQL/SQLite via Eloquent), and a legacy Node CLI.
+- Layers: Backend (Laravel), Frontend (Inertia SPA — Vue currently, React migration in progress using Vibe UI KIT), Data (MySQL/SQLite via Eloquent), and a legacy Node CLI.
 - Backend: routes in `webapp/routes/web.php` and `webapp/routes/api.php`; controllers in `webapp/app/Http/Controllers`; models in `webapp/app/Models`; jobs/listeners in `webapp/app/Jobs` and `webapp/app/Listeners`.
-- Frontend: Vue pages/components under `webapp/resources/`; assets built with Vite; served through Inertia responses.
+- Frontend: Inertia pages/components under `webapp/resources/`. Legacy pages are Vue; new/refactored pages use React with Vibe UI KIT. Assets built with Vite; served through Inertia responses.
 - Data: migrations in `webapp/database/migrations`; seeders in `webapp/database/seeders`.
 - CLI: independent from the webapp; reads `cases/` and uses `utils/`. Keep it decoupled from Laravel code.
 - Request flow: Browser → Laravel route → Controller returns Inertia view → Vue page mounts. API calls hit `routes/api.php` and return JSON.
@@ -19,14 +19,16 @@
 - Run app: `composer dev` — Laravel, queue, logs, and Vite concurrently. Alt: `php artisan serve` and `npm run dev`.
 - DB: `php artisan migrate` (optionally `--seed`).
 - Webapp tests: `composer test` (Pest/PHPUnit).
-- Frontend build: `npm run dev` (Vite) / `npm run build` (prod).
+- Frontend build: `npm run dev` (Vite) / `npm run build` (prod). For React pages, ensure Inertia React is installed; Vue pages continue to work unchanged.
 - CLI run: `npm start` or `npm run dev`.
 - CLI tests: `npm test` / `npm run test:watch` (Vitest).
 - Utilities: `npm run validate-cases` (check `cases/`), `npm run health` (env sanity check).
 
 ## Coding Style & Naming Conventions
 - PHP: PSR‑12; follow Laravel conventions for Controllers, models, migrations, and routes. Classes use PascalCase.
-- JS/TS: 2‑space indent, ESM modules. Variables/functions camelCase; classes PascalCase. Vue components in `webapp/resources/` use PascalCase filenames.
+- JS/TS: 2‑space indent, ESM modules. Variables/functions camelCase; classes PascalCase.
+- Vue (legacy): components in `webapp/resources/` follow PascalCase filenames.
+- React (new): components/pages in `webapp/resources/` follow PascalCase filenames. Use Vibe UI KIT components where applicable.
 - Lint/format (webapp): `npm run lint`, `npm run format`, `npm run format:check`. Keep imports ordered and Tailwind classes tidy.
 
 ## Testing Guidelines
@@ -45,6 +47,7 @@
 ## Agent Role & Prompt-First Workflow
 
 - Primary role: General coding and problem‑solving in this repo (implement, refactor, debug, test). Prompt building is an opt‑in macro.
+- Frontend direction: Prefer React + Inertia for new work; keep Vue pages stable until migrated. Do not mix Vue and React within a single page.
 - Vibe Kanban: For new‑function work using prompts, create exactly three tasks (Diagnosis, Implementation, Testing) and keep artifacts in sync. Task titles and objective actions must be elaborative, detailed prompts (not short labels).
 - Shared slug: Define a single kebab‑case `<feature-slug>` in Diagnosis and reuse across all agents/files.
 - Filenames (store under `.claude/kanban/`):
@@ -491,3 +494,10 @@ How to use this template
 - Replace placeholders like `{{Module Name}}`, `{{module-path}}`, `{{PrimaryEntity}}`, `{{Record}}`, and `{{form-fields-list}}` with your domain terms.
 - Pick sensible defaults: `{{autosave-interval-seconds}}` (e.g., 10), `{{max-attachment-mb}}` (e.g., 5), and compute `{{max-attachment-kb}} = {{max-attachment-mb}} * 1024`.
 - Keep the module isolated unless integration is explicitly required.
+
+## Vibe Kanban Scripts (project: osce)
+
+- Setup script (osce): Installs deps, creates `webapp/database/database.sqlite`, then runs `php artisan migrate:fresh --force --seed`.
+  - Recommended additions: copy `.env.example` to `.env` if missing, set `DB_CONNECTION=sqlite` and `DB_DATABASE=database/database.sqlite`, run `php artisan key:generate`, and consider `php artisan storage:link`.
+- Dev script (osce): Runs Laravel server, queue listener, logs (pail), and Vite.
+  - Recommended hardening: fall back gracefully if `pail` is not installed; prefer `queue:work --tries=1` for production-like behavior; keep the same port (`8001`) documented.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,33 +2,35 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Migration notice: The frontend is being migrated from Vue 3 to React using Inertia (React adapter) and the Vibe UI KIT. Legacy pages remain in Vue during the transition. Prefer React for new features; keep Vue pages stable until migrated.
+
 ## Project Overview
 
-This is a Laravel project with a Vue.js frontend using Inertia.js. The main application code is located in the `webapp` directory. It uses TypeScript, Tailwind CSS, and shadcn-vue for UI components.
+This is a Laravel project with an Inertia-powered SPA frontend. The main application code is located in the `webapp` directory. We currently have a mix of Vue (legacy) and React (new) pages. Styling uses Tailwind; UI components are shadcn-vue for legacy and Vibe UI KIT for new React pages.
 
 ## Technology Stack
 
 - **Backend**: Laravel
-- **Frontend**: Vue.js with Inertia.js
+- **Frontend**: Inertia SPA — Vue (legacy), React (in progress) with Vibe UI KIT
 - **Styling**: Tailwind CSS
-- **UI Components**: shadcn-vue
+- **UI Components**: shadcn-vue (legacy), Vibe UI KIT (React)
 - **Language**: TypeScript (frontend), PHP (backend)
 
 ## Common Commands
 
 All commands should be run from the `webapp` directory.
 
-- **`npm run dev`**: Starts the Vite development server for frontend assets.
-- **`npm run build`**: Compiles and bundles frontend assets for production.
-- **`npm run lint`**: Lints the codebase using ESLint and attempts to fix issues.
-- **`npm run format`**: Formats the code using Prettier.
-- **`npm run format:check`**: Checks the formatting without writing changes.
-- **`composer install`**: Installs PHP dependencies.
-- **`php artisan test`**: Runs the PHPUnit tests.
+- `npm run dev`: Starts the Vite development server for frontend assets.
+- `npm run build`: Compiles and bundles frontend assets for production.
+- `npm run lint`: Lints the codebase using ESLint and attempts to fix issues.
+- `npm run format`: Formats the code using Prettier.
+- `npm run format:check`: Checks the formatting without writing changes.
+- `composer install`: Installs PHP dependencies.
+- `php artisan test`: Runs the PHPUnit tests.
 
 ## Architecture
 
-The application follows a standard Laravel structure with Vue.js and Inertia for the frontend.
+The application follows a standard Laravel structure with Inertia for the frontend. Use React + Inertia for new work; Vue + Inertia remains for legacy pages until migrated.
 
 ### Models
 
@@ -99,17 +101,17 @@ alwaysApply: true
   - Use `Inertia.get()`, `Inertia.post()`, `Inertia.put()`, `Inertia.delete()` instead of regular APIs
   - Leverage `Inertia.visit()` for navigation
   - Use `router.visit()` with proper options for form submissions
-  - Always check todos to ensure Inertia architecture is used first before considering alternatives
+  - For new work, prefer the React adapter and Vibe UI KIT; for existing Vue pages, stay within the current Vue structure until migrated.
 
 ## **Component & Page Management**
 
-- **ShadCN Vue is already installed** - Don't reinstall it. Always use existing shadcn components whenever possible. If asked to install a new component, install only that specific component.
+- **Vibe UI KIT (React) is the default for new UI**. shadcn-vue is installed for legacy Vue pages — do not rework unless migrating the page fully to React.
 
 - **New Page Creation Process:**
-  1. Create Vue page in Resources/js/Pages/
-  2. Add page to AppSidebar.vue navigation
-  3. Create corresponding Laravel Controller
-  4. Add routes in web.php with proper Inertia responses
+  1. Create React page in `resources/js/Pages/` (or relevant feature dir) using Inertia React.
+  2. Add navigation entry to the appropriate layout/sidebar.
+  3. Create corresponding Laravel Controller.
+  4. Add routes in `web.php` with proper Inertia responses.
 
 - **Error Handling:**
   - Use Browser Logs (Laravel Boost MCP Tools) to check latest errors
@@ -829,5 +831,4 @@ Use this when asking for a detailed prompt to fix or modify an existing feature.
 -   Replace all placeholders like `{{Feature Name}}` with specific details about the task.
 -   Provide the *actual code* for the "Current Implementation" to give the AI full context.
 -   Be as explicit as possible in the "Specified Approach & Required Changes" section.
-
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
-# AI Development Rules and Guidelines
+# Gemini Integration — Dev Rules & Setup (Vue → React Migration)
 
-This document consolidates the key rules and guidelines for AI-assisted development in this Laravel + Inertia.js + Vue.js project.
+This document consolidates rules and setup for Gemini usage in this Laravel + Inertia SPA. We are migrating the frontend from Vue to React using the Vibe UI KIT (see PR #62). Backend Gemini services and APIs remain unchanged; React pages call the same Laravel endpoints.
 
 ## Core Architecture & Development Principles
 
@@ -23,12 +23,14 @@ This document consolidates the key rules and guidelines for AI-assisted developm
   - Leverage `Inertia.visit()` for navigation
   - Use `router.visit()` with proper options for form submissions
   - Check todos to ensure Inertia architecture is used first before considering alternatives
+  - For new UI, prefer React + Inertia with Vibe UI KIT; legacy Vue pages remain until migrated.
 
 ## Technology Stack & Versions
 - **PHP** - 8.2.29
 - **Laravel Framework** - v12
 - **Inertia Laravel** - v2
-- **Vue.js** - v3  
+- **Vue.js** - v3 (legacy)
+- **React** - In progress (Vibe UI KIT)
 - **Tailwind CSS** - v4
 - **Pest** - v3
 - **Laravel Pint** - v1
@@ -36,12 +38,31 @@ This document consolidates the key rules and guidelines for AI-assisted developm
 ## Development Workflow
 
 ### Component & Page Management
-- **ShadCN Vue is already installed** - Don't reinstall it. Install specific components only when needed
-- **New Page Creation Process:**
-  1. Create Vue page in `Resources/js/Pages/`
-  2. Add page to AppSidebar.vue navigation
-  3. Create corresponding Laravel Controller
-  4. Add routes in web.php with proper Inertia responses
+- React (preferred for new work): Use Inertia React + Vibe UI KIT components; keep Tailwind styles consistent.
+- Vue (legacy): shadcn-vue remains; only migrate when converting an entire page.
+- New Page Creation Process:
+  1. Create React page in `resources/js/Pages/` (or feature subfolder) using Inertia React.
+  2. Add navigation entry in the appropriate layout/sidebar.
+  3. Create/adjust Laravel Controller to return Inertia response.
+  4. Add routes in `web.php`.
+
+## Gemini Configuration (env)
+
+Set in `webapp/.env` (see `.env.example`):
+
+```
+GEMINI_API_KEY=your_gemini_api_key_here
+GEMINI_MODEL=gemini-1.5-flash
+GEMINI_TIMEOUT=30                 # seconds (optional)
+GEMINI_RATE_LIMIT=60              # requests/minute (optional)
+GEMINI_MAX_CONCURRENT=5           # in-flight requests (optional)
+GEMINI_FALLBACK_ENABLED=true      # allow degraded results on parse issues (optional)
+```
+
+Notes
+- `config/services.php` and `config/gemini.php` both read `GEMINI_MODEL`. Default differs by file; set the env var explicitly to avoid mismatch.
+- Never commit real keys. Keep `.env.example` updated only with placeholders.
+- Dev DB defaults to SQLite; long-running Gemini work should run via the queue worker (dev script starts one).
 
 ### Error Handling
 - Use Browser Logs (Laravel Boost MCP Tools) to check latest errors
@@ -76,11 +97,10 @@ This document consolidates the key rules and guidelines for AI-assisted developm
 
 ## Frontend Rules
 
-### Vue + Inertia
-- Vue components must have single root element
-- Use `router.visit()` or `<Link>` for navigation
-- Use `router.post()` for form handling, not regular forms
-- Minimize web reloading - follow SPA principles
+### Inertia (Vue legacy + React new)
+- Use `<Link>`/`router.visit()` for navigation.
+- Use Inertia forms or `router.post/put/delete` for mutations.
+- Avoid raw fetch calls from pages; go through controllers and services.
 
 ### Tailwind CSS v4
 - Use Tailwind v4 syntax: `@import "tailwindcss"` not `@tailwind` directives
@@ -144,3 +164,34 @@ When creating AI prompts for implementation tasks:
 - Modify existing rules when better examples exist
 - Remove outdated patterns and update references
 - Cross-reference related rules for consistency
+
+## Where Gemini Is Used (code references)
+
+- `app/Services/AiPatientService.php`: AI patient chat responses (Gemini 1.5 flash endpoint).
+- `app/Services/GeminiService.php`: Core Gemini client with web search grounding and parsing.
+- `app/Services/AiAssessorService.php`: Session scoring and assessment via Gemini.
+- `app/Services/AreaAssessor.php`: Area-specific clinical assessments via Gemini.
+- `app/Services/RationalizationEvaluationService.php`: Post-session rationalization using Gemini.
+- `app/Services/ResultReducer.php`: Bundles model metadata into results (reads configured model).
+- `app/Http/Controllers/OsceAssessmentController.php`: Exposes assess/status/results endpoints (uses configured model).
+
+## API Endpoints (Gemini-backed)
+
+- `POST /api/osce/sessions/{session}/assess` → runs assessment (queue-backed for long tasks).
+- `GET  /api/osce/sessions/{session}/status` → assessment status.
+- `GET  /api/osce/sessions/{session}/results` → assessment results view/data.
+- OSCE Chat endpoints: `POST /api/osce/chat/start`, `POST /api/osce/chat/message`, `GET /api/osce/chat/history/{session}`.
+
+## Troubleshooting
+
+- 401/403 from Gemini: verify `GEMINI_API_KEY` and that the key supports the selected `GEMINI_MODEL`.
+- Timeouts: raise `GEMINI_TIMEOUT` or run via queues to prevent request timeouts.
+- Rate limiting: tune `GEMINI_RATE_LIMIT` and `GEMINI_MAX_CONCURRENT` to your key limits.
+- Parsing errors: `GEMINI_FALLBACK_ENABLED=true` allows structured fallback; check logs for raw content.
+- Tests failing due to missing API key: tests can set `config(['services.gemini.api_key' => null])` to disable real calls (see tests under `webapp/tests/Feature/*Assessment*Test.php`).
+
+## Migration Note (PR #62)
+
+- React UI migration does not change Gemini configuration or routes.
+- Continue calling Laravel endpoints from React (Inertia) pages; no direct client-side Gemini calls.
+- Keep all Gemini work in services/controllers; do not embed API keys in frontend code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Web-Based OSCE Training Platform
 
-A modern web application for Objective Structured Clinical Examination (OSCE) training, featuring AI-powered patient simulation, community forums, and assessment tools. Built with **Laravel 12** and **Vue 3** via [Inertia.js](https://inertiajs.com).
+A modern web application for Objective Structured Clinical Examination (OSCE) training, featuring AI-powered patient simulation, community forums, and assessment tools.
+
+Migration notice: We are actively migrating the frontend from Vue 3 to React using the Vibe UI KIT. The app currently runs with Vue via Inertia in many areas while new/updated screens are being implemented in React (Inertia React + Vite). Expect mixed frontend stacks during this transition.
 
 ## 🚀 Quick Start
 
@@ -41,6 +43,10 @@ A modern web application for Objective Structured Clinical Examination (OSCE) tr
 
 Visit `http://localhost:8000` to access the application.
 
+Notes during React migration
+- New UI should use React with Inertia React and Vite; legacy pages remain in Vue until migrated.
+- Component library: Vibe UI KIT (React). For legacy Vue pages, shadcn-vue remains in place.
+
 ## 🏥 Features
 
 - **AI Patient Simulation** - Interactive conversations with AI patients powered by Google Gemini
@@ -53,8 +59,8 @@ Visit `http://localhost:8000` to access the application.
 ## 🛠 Technology Stack
 
 - **Backend**: Laravel 12 (PHP 8.2+)
-- **Frontend**: Vue 3 + TypeScript + Inertia.js 2.0
-- **Styling**: Tailwind CSS v4 + shadcn-vue components
+- **Frontend**: Vue 3 + Inertia (current), React + Inertia (in progress) using Vibe UI KIT
+- **Styling**: Tailwind CSS v4; shadcn-vue (legacy), Vibe UI KIT (React)
 - **Testing**: Pest + PHPUnit
 - **Database**: PostgreSQL (production) / SQLite (development)
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,20 +1,24 @@
-# Laravel + Vue Starter Kit
+# Laravel + Inertia Frontend (Vue → React Migration)
 
 ## Introduction
 
-Our Vue starter kit provides a robust, modern starting point for building Laravel applications with a Vue frontend using [Inertia](https://inertiajs.com).
+We are migrating the frontend from Vue 3 to React using Inertia and the Vibe UI KIT. During this transition, existing pages continue to use Vue via Inertia, while new and refactored screens are implemented in React (Inertia React + Vite).
 
-Inertia allows you to build modern, single-page Vue applications using classic server-side routing and controllers. This lets you enjoy the frontend power of Vue combined with the incredible backend productivity of Laravel and lightning-fast Vite compilation.
-
-This Vue starter kit utilizes Vue 3 and the Composition API, TypeScript, Tailwind, and the [shadcn-vue](https://www.shadcn-vue.com) component library.
+For legacy Vue pages, we still use the Composition API, TypeScript, Tailwind, and the [shadcn-vue](https://www.shadcn-vue.com) component library. For new React pages, prefer Vibe UI KIT components and keep styling consistent with Tailwind.
 
 ## Official Documentation
 
-Documentation for all Laravel starter kits can be found on the [Laravel website](https://laravel.com/docs/starter-kits).
+- Laravel: https://laravel.com/docs
+- Inertia.js: https://inertiajs.com
+- React adapter: https://inertiajs.com/client-side-setup (React)
+- Vue adapter: https://inertiajs.com/client-side-setup (Vue)
 
 ## Contributing
 
-Thank you for considering contributing to our starter kit! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+When adding or changing UI:
+- Prefer React + Inertia for new features (Vibe UI KIT components).
+- Keep Vue pages stable; migrate incrementally, page-by-page.
+- Do not mix Vue and React within the same page.
 
 ## Code of Conduct
 
@@ -22,4 +26,4 @@ In order to ensure that the Laravel community is welcoming to all, please review
 
 ## License
 
-The Laravel + Vue starter kit is open-sourced software licensed under the MIT license.
+MIT License


### PR DESCRIPTION
Last task (on Vibe Kanban → You can check using MCP) i tried migrating my app to React using Vibe UI KIT 

so README.md webapp/README.md AGENTS.md and CLAUDE.md is outdated, plase watch our latest PR to get the context, and update the MD Documentations that this is still a process to migrate to React

Also can you check using Vibe_Kanban the Dev Script, Setup Script of this Projects, is it correct (project name : osce)

here's a context of what script does

[Vibe Kanban Context]
Vibe-Kanban is a Kanban dashboard to manage AI coding agents. It isolates tasks in git worktrees so agents can generate, refactor, and test code without wrecking your main branch.
Setup Script → Runs once when opening a project. Installs deps, applies migrations, preps the environment.
Dev Script → Spins up the live dev environment (hot-reload, servers, watchers) so agent output can be tested immediately.
These scripts give agents a consistent sandbox: setup ensures they all start from the same baseline, dev keeps feedback loops fast.
In short: scripts = automation glue that keeps agent-driven coding predictable and reproducible.